### PR TITLE
Revert "remove ecmwflibs from requirements"

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -22,6 +22,7 @@ classifiers =
 [options]
 packages = find:
 install_requires =
+    ecmwflibs
     numpy
     pandas
     rasterio


### PR DESCRIPTION
This reverts commit 38da6910a50e3651d7b7c790085a2e31a08d3505.

fixes the error message `UserWarning: Failed to load cfgrib - most likely there is a problem accessing the ecCodes library. Try `import cfgrib` to get the full error message`