### PR TITLE
drop python 3.6, fix `xarray.open_rasterio` deprecation warning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,6 @@ classifiers =
     License :: OSI Approved :: MIT License
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
@@ -31,7 +30,7 @@ install_requires =
     xarray[io]
     importlib-metadata;python_version<"3.8"
     importlib-resources;python_version<"3.8"
-python_requires = >=3.6.1
+python_requires = >=3.7
 
 [options.packages.find]
 exclude =

--- a/tests/w2w_test.py
+++ b/tests/w2w_test.py
@@ -1,5 +1,7 @@
 import os
 import pytest
+import rioxarray
+from affine import Affine
 import shutil
 from w2w.w2w import main
 from w2w.w2w import check_lcz_wrf_extent
@@ -94,13 +96,11 @@ def test_create_wrf_gridinfo(tmpdir):
     }
     create_wrf_gridinfo(info)
     assert os.listdir(tmpdir) == ['dst_gridinfo.tif']
-    tif = xarray.open_rasterio(info['dst_gridinfo'])
-    assert tif.crs == '+init=epsg:4326'
-    assert tif.transform == pytest.approx(
-        (
+    tif = rioxarray.open_rasterio(info['dst_gridinfo'])
+    assert tif.rio.crs.to_proj4() == '+init=epsg:4326'
+    assert tif.rio.transform() == Affine(
             0.01000213623046875, 0.0, -1.4050254821777344,
             0.0, 0.010000228881835938, 41.480000495910645,
-        )
     )
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36, py37, py38, py39, pre-commit
+envlist = py37, py38, py39, pre-commit
 skip_missing_interpreters = true
 
 [testenv]


### PR DESCRIPTION
resolves #16

This drops support for python 3.6, to be able to fix the `xarray` deprecation warning. It looks like there were a few breaking changes to the new `rioxarray` API, now some attributes can only be acceses via `.rio...`, therefore I had to make those tedious small changes...

Please have a look and check if the results not only pass the tests but are valid.