### PR TITLE
fix CI badges in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![ci](https://github.com/matthiasdemuzere/w2w/actions/workflows/ci.yml/badge.svg)](https://github.com/matthiasdemuzere/w2w/actions/workflows/ci.yml)
+[![pre-commit.ci status](https://results.pre-commit.ci/badge/github/matthiasdemuzere/w2w/main.svg)](https://results.pre-commit.ci/latest/github/matthiasdemuzere/w2w/main)
 
 w2w.py
 ======

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![ci](https://github.com/theendlessriver13/w2w/actions/workflows/ci.yml/badge.svg)](https://github.com/theendlessriver13/w2w/actions/workflows/ci.yml)
+[![ci](https://github.com/matthiasdemuzere/w2w/actions/workflows/ci.yml/badge.svg)](https://github.com/matthiasdemuzere/w2w/actions/workflows/ci.yml)
 
 w2w.py
 ======


### PR DESCRIPTION
Unfortunately I made a mistake when setting up CI and forgot to change the username for the CI badge and did not add the `pre-commit.ci` badge.

This is now fixed and will also be fixed on PyPi with the next release published there.