### PR TITLE
fix deprecation warning for importlib resources

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -29,8 +29,8 @@ install_requires =
     rioxarray
     scipy
     xarray[io]
-    importlib-metadata;python_version<"3.8"
-    importlib-resources;python_version<"3.8"
+    importlib-metadata;python_version<"3.9"
+    importlib-resources;python_version<"3.9"
 python_requires = >=3.6.1
 
 [options.packages.find]

--- a/w2w/w2w.py
+++ b/w2w/w2w.py
@@ -13,10 +13,10 @@ import traceback
 from typing import Dict
 from scipy import stats
 
-if sys.version_info < (3, 8):  # pragma: no cover (>=py38)
+if sys.version_info < (3, 9):  # pragma: <3.9 cover
     import importlib_metadata
     import importlib_resources
-else:  # pragma: no cover (<py38)
+else:  # pragma: >=3.9 cover
     import importlib.metadata as importlib_metadata
     import importlib.resources as importlib_resources
 
@@ -316,7 +316,7 @@ def _ucp_resampler(
 
     # Read the look-up table
     ucp_table = pd.read_csv(
-        importlib_resources.open_text('w2w.resources', 'LCZ_UCP_lookup.csv'),
+        importlib_resources.files('w2w.resources').joinpath('LCZ_UCP_lookup.csv'),
         sep=',', index_col=0
     ).iloc[:17, :]
 
@@ -405,7 +405,7 @@ def _hgt_resampler(
 
     # Read the look-up table
     ucp_table = pd.read_csv(
-        importlib_resources.open_text('w2w.resources', 'LCZ_UCP_lookup.csv'),
+        importlib_resources.files('w2w.resources').joinpath('LCZ_UCP_lookup.csv'),
         sep=',', index_col=0
     ).iloc[:17, :]
 
@@ -510,7 +510,7 @@ def _compute_hi_distribution(
 
     # Read the look-up table
     ucp_table = pd.read_csv(
-        importlib_resources.open_text('w2w.resources', 'LCZ_UCP_lookup.csv'),
+        importlib_resources.files('w2w.resources').joinpath('LCZ_UCP_lookup.csv'),
         sep=',', index_col=0
     ).iloc[:17, :]
 
@@ -1148,7 +1148,7 @@ def checks_and_cleaning(
     # Take expected ranges from the look-up table,
     # add some margin for changes due to interpolation.
     ucp_table = pd.read_csv(
-        importlib_resources.open_text('w2w.resources', 'LCZ_UCP_lookup.csv'),
+        importlib_resources.files('w2w.resources').joinpath('LCZ_UCP_lookup.csv'),
         sep=',', index_col=0
     ).iloc[:17, :]
 


### PR DESCRIPTION
resolves #17

this should silence the deprecation warnings. In combination with #24 this should fix all warnings caused by this package. All existing warnings are caused by dependencies.