### PR TITLE
apply black, and add more linters

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ ci:
 
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.0.1
+    rev: v4.1.0
     hooks:
     -   id: trailing-whitespace
     -   id: end-of-file-fixer
@@ -11,10 +11,22 @@ repos:
     -   id: name-tests-test
     -   id: requirements-txt-fixer
     -   id: debug-statements
+    -   id: double-quote-string-fixer
+    -   id: check-merge-conflict
+-   repo: https://github.com/asottile/reorder_python_imports
+    rev: v2.7.1
+    hooks:
+    -   id: reorder-python-imports
+        args: [--py3-plus]
 -   repo: https://github.com/asottile/setup-cfg-fmt
-    rev: v1.17.0
+    rev: v1.20.0
     hooks:
     -   id: setup-cfg-fmt
+-   repo: https://github.com/psf/black
+    rev: 22.1.0
+    hooks:
+      - id: black
+        args: [--skip-string-normalization]
 -   repo: https://github.com/pre-commit/mirrors-mypy
     rev: v0.931
     hooks:

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,6 +16,7 @@ classifiers =
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Programming Language :: Python :: Implementation :: CPython
 
 [options]

--- a/setup.py
+++ b/setup.py
@@ -1,2 +1,3 @@
 from setuptools import setup
+
 setup()

--- a/tests/w2w_test.py
+++ b/tests/w2w_test.py
@@ -1,41 +1,44 @@
+import argparse
 import os
-from unittest import mock
-import pytest
-import rioxarray as rxr
-from affine import Affine
-from rasterio.warp import reproject, Resampling
 import shutil
-import w2w.w2w
-from w2w.w2w import main
-from w2w.w2w import Info
-from w2w.w2w import _check_lcz_wrf_extent
-from w2w.w2w import _replace_lcz_number
-from w2w.w2w import check_lcz_integrity
-from w2w.w2w import _calc_distance_coord
-from w2w.w2w import wrf_remove_urban
-from w2w.w2w import create_wrf_gridinfo
-from w2w.w2w import _get_SW_BW
-from w2w.w2w import _get_lcz_arr
-from w2w.w2w import _ucp_resampler
-from w2w.w2w import _hgt_resampler
-from w2w.w2w import _scale_hi
-from w2w.w2w import _get_truncated_normal_sample
-from w2w.w2w import _check_hi_values
-from w2w.w2w import _compute_hi_distribution
-from w2w.w2w import _hi_resampler
-from w2w.w2w import _lcz_resampler
-from w2w.w2w import _add_frc_lu_index_2_wrf
-from w2w.w2w import _initialize_urb_param
-from w2w.w2w import create_lcz_params_file
-from w2w.w2w import create_lcz_extent_file
-from w2w.w2w import expand_land_cat_parents
-from w2w.w2w import checks_and_cleaning
-import pandas as pd
-import xarray as xr
+from unittest import mock
+
 import numpy as np
 import pandas as pd
+import pytest
+import rioxarray as rxr
+import xarray as xr
+from affine import Affine
 from pytest import approx
-import argparse
+from rasterio.warp import reproject
+from rasterio.warp import Resampling
+
+import w2w.w2w
+from w2w.w2w import _add_frc_lu_index_2_wrf
+from w2w.w2w import _calc_distance_coord
+from w2w.w2w import _check_hi_values
+from w2w.w2w import _check_lcz_wrf_extent
+from w2w.w2w import _compute_hi_distribution
+from w2w.w2w import _get_lcz_arr
+from w2w.w2w import _get_SW_BW
+from w2w.w2w import _get_truncated_normal_sample
+from w2w.w2w import _hgt_resampler
+from w2w.w2w import _hi_resampler
+from w2w.w2w import _initialize_urb_param
+from w2w.w2w import _lcz_resampler
+from w2w.w2w import _replace_lcz_number
+from w2w.w2w import _scale_hi
+from w2w.w2w import _ucp_resampler
+from w2w.w2w import check_lcz_integrity
+from w2w.w2w import checks_and_cleaning
+from w2w.w2w import create_lcz_extent_file
+from w2w.w2w import create_lcz_params_file
+from w2w.w2w import create_wrf_gridinfo
+from w2w.w2w import expand_land_cat_parents
+from w2w.w2w import Info
+from w2w.w2w import main
+from w2w.w2w import wrf_remove_urban
+
 
 @pytest.fixture
 def info_mock():
@@ -61,12 +64,13 @@ def test_argparse_shows_help():
     with pytest.raises(SystemExit):
         main(['--help'])
 
+
 def test_create_info_dict():
     args = argparse.Namespace(
-        lcz_file= 'lcz_file.tif',
-        wrf_file = 'wrf_file.nc',
-        io_dir = 'input/directory',
-        built_lcz = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+        lcz_file='lcz_file.tif',
+        wrf_file='wrf_file.nc',
+        io_dir='input/directory',
+        built_lcz=[1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
     )
     info = Info.from_argparse(args)
     # info is Dict, with 9 keys
@@ -85,33 +89,51 @@ def test_create_info_dict():
     # Last entry is list of built LCZs
     assert info.BUILT_LCZ == [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
 
+
 def test_replace_lcz_number_ok(info_mock):
-    info = info_mock({
-        'src_file': 'testing/Shanghai.tif',
-    })
+    info = info_mock(
+        {
+            'src_file': 'testing/Shanghai.tif',
+        }
+    )
     LCZ_BAND = 0
     lcz = rxr.open_rasterio(info.src_file)[LCZ_BAND, :, :]
 
     lcz_100 = np.array(
-        [1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
-         101, 102, 103, 104, 105, 106, 107]
+        [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 101, 102, 103, 104, 105, 106, 107]
     )
     lcz_new = _replace_lcz_number(
-            lcz=lcz,
-            lcz_to_change=lcz_100,
-        )
+        lcz=lcz,
+        lcz_to_change=lcz_100,
+    )
 
     # Test whether LCZs 100+ are converted to 11+
-    assert (np.unique(lcz_new.data).tolist() ==
-            [1, 2, 3, 4, 5, 6, 8, 10, 11, 12, 14, 15, 17])
+    assert np.unique(lcz_new.data).tolist() == [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        8,
+        10,
+        11,
+        12,
+        14,
+        15,
+        17,
+    ]
+
 
 def test_check_lcz_integrity_lcz_numbers_as_expected(capsys, tmpdir, info_mock):
 
-    info = info_mock({
-        'src_file': 'sample_data/lcz_zaragoza.tif',
-        'src_file_clean': os.path.join(tmpdir, 'lcz_zaragoza_clean.tif'),
-        'dst_file': 'sample_data/geo_em.d04.nc',
-    })
+    info = info_mock(
+        {
+            'src_file': 'sample_data/lcz_zaragoza.tif',
+            'src_file_clean': os.path.join(tmpdir, 'lcz_zaragoza_clean.tif'),
+            'dst_file': 'sample_data/geo_em.d04.nc',
+        }
+    )
     LCZ_BAND = 0
     check_lcz_integrity(info=info, LCZ_BAND=LCZ_BAND)
     out, _ = capsys.readouterr()
@@ -121,11 +143,13 @@ def test_check_lcz_integrity_lcz_numbers_as_expected(capsys, tmpdir, info_mock):
 
 def test_check_lcz_integrity_crs_changed(capsys, tmpdir, info_mock):
 
-    info = info_mock({
-        'src_file': 'testing/Shanghai.tif',
-        'src_file_clean': os.path.join(tmpdir, 'Shanghai_clean.tif'),
-        'dst_file': 'testing/geo_em.d02_Shanghai.nc',
-    })
+    info = info_mock(
+        {
+            'src_file': 'testing/Shanghai.tif',
+            'src_file_clean': os.path.join(tmpdir, 'Shanghai_clean.tif'),
+            'dst_file': 'testing/geo_em.d02_Shanghai.nc',
+        }
+    )
     LCZ_BAND = 0
     check_lcz_integrity(info=info, LCZ_BAND=LCZ_BAND)
     out, _ = capsys.readouterr()
@@ -133,12 +157,13 @@ def test_check_lcz_integrity_crs_changed(capsys, tmpdir, info_mock):
     assert os.listdir(tmpdir) == ['Shanghai_clean.tif']
 
 
-
 def test_check_lcz_wrf_extent_lcz_too_small(capsys, info_mock):
-    info = info_mock({
-        'src_file': 'testing/lcz_too_small.tif',
-        'dst_file': 'sample_data/geo_em.d04.nc',
-    })
+    info = info_mock(
+        {
+            'src_file': 'testing/lcz_too_small.tif',
+            'dst_file': 'sample_data/geo_em.d04.nc',
+        }
+    )
     LCZ_BAND = 0
 
     lcz = rxr.open_rasterio(info.src_file)[LCZ_BAND, :, :]
@@ -148,9 +173,7 @@ def test_check_lcz_wrf_extent_lcz_too_small(capsys, info_mock):
         _check_lcz_wrf_extent(lcz=lcz, wrf=wrf)
 
     out, _ = capsys.readouterr()
-    assert (
-        'ERROR: LCZ domain should be larger than WRF domain'
-    ) in out
+    assert ('ERROR: LCZ domain should be larger than WRF domain') in out
     # TODO maybe add the actual values to check they are correct
     assert (
         'ERROR: LCZ domain should be larger than WRF domain '
@@ -160,10 +183,12 @@ def test_check_lcz_wrf_extent_lcz_too_small(capsys, info_mock):
 
 
 def test_check_lcz_wrf_extent_ok(capsys, info_mock):
-    info = info_mock({
-        'src_file': 'sample_data/lcz_zaragoza.tif',
-        'dst_file': 'sample_data/geo_em.d04.nc',
-    })
+    info = info_mock(
+        {
+            'src_file': 'sample_data/lcz_zaragoza.tif',
+            'dst_file': 'sample_data/geo_em.d04.nc',
+        }
+    )
     LCZ_BAND = 0
 
     lcz = rxr.open_rasterio(info.src_file)[LCZ_BAND, :, :]
@@ -172,16 +197,20 @@ def test_check_lcz_wrf_extent_ok(capsys, info_mock):
     out, _ = capsys.readouterr()
     assert '> LCZ domain is covering WRF domain' in out
 
+
 def test_check_lcz_integrity_clean_file_written(tmpdir, info_mock):
 
-    info = info_mock({
-        'src_file': 'testing/Shanghai.tif',
-        'dst_file': 'testing/geo_em.d02_Shanghai.nc',
-        'src_file_clean': os.path.join(tmpdir, 'Shanghai_clean.tif'),
-    })
+    info = info_mock(
+        {
+            'src_file': 'testing/Shanghai.tif',
+            'dst_file': 'testing/geo_em.d02_Shanghai.nc',
+            'src_file_clean': os.path.join(tmpdir, 'Shanghai_clean.tif'),
+        }
+    )
     LCZ_BAND = 0
     check_lcz_integrity(info=info, LCZ_BAND=LCZ_BAND)
     assert os.listdir(tmpdir) == ['Shanghai_clean.tif']
+
 
 @pytest.mark.parametrize(
     ('coords', 'expected'),
@@ -190,24 +219,24 @@ def test_check_lcz_integrity_clean_file_written(tmpdir, info_mock):
         pytest.param((-89, 0, -90, 1), 111194, id='near southern pole'),
         pytest.param((-60, -10, -70, -12), 1115764, id='southern eastern hemisphere'),
         pytest.param((-1, 0, 1, 2), 314498, id='across equator'),
-        pytest.param((45, 179, 46, -179), 191461, id='across dateline')
+        pytest.param((45, 179, 46, -179), 191461, id='across dateline'),
     ),
 )
 def test_calc_distance_coord(coords, expected):
     assert _calc_distance_coord(*coords) == pytest.approx(expected, abs=1)
+
 
 @pytest.mark.parametrize(
     ('dst_file', 'dst_nu_file'),
     (
         pytest.param('testing/5by5.nc', '5by5_new.nc', id='all cat'),
         pytest.param('testing/5by5_20cat.nc', '5by5_20cat_new.nc', id='20 cat'),
-    )
+    ),
 )
 def test_wrf_remove_urban(tmpdir, dst_file, dst_nu_file, info_mock):
-    info = info_mock({
-        'dst_file': dst_file,
-        'dst_nu_file': os.path.join(tmpdir, dst_nu_file)
-    })
+    info = info_mock(
+        {'dst_file': dst_file, 'dst_nu_file': os.path.join(tmpdir, dst_nu_file)}
+    )
     old_ds = xr.open_dataset(info.dst_file)
     wrf_remove_urban(info=info, NPIX_NLC=9)
     ds = xr.open_dataset(info.dst_nu_file)
@@ -236,10 +265,12 @@ def test_wrf_remove_urban(tmpdir, dst_file, dst_nu_file, info_mock):
 
 def test_wrf_remove_urban_output_already_exists_is_overwritten(tmpdir, info_mock):
     tmpdir.ensure('5by5_new.nc')
-    info = info_mock({
-        'dst_file': 'testing/5by5.nc',
-        'dst_nu_file': os.path.join(tmpdir, '5by5_new.nc')
-    })
+    info = info_mock(
+        {
+            'dst_file': 'testing/5by5.nc',
+            'dst_nu_file': os.path.join(tmpdir, '5by5_new.nc'),
+        }
+    )
     assert os.listdir(tmpdir) == ['5by5_new.nc']
     m_time_old = os.path.getmtime(info.dst_nu_file)
     wrf_remove_urban(info=info, NPIX_NLC=9)
@@ -247,51 +278,71 @@ def test_wrf_remove_urban_output_already_exists_is_overwritten(tmpdir, info_mock
 
 
 def test_create_wrf_gridinfo(tmpdir, info_mock):
-    info = info_mock({
-        'dst_nu_file': 'testing/5by5.nc',
-        'dst_gridinfo': os.path.join(tmpdir, 'dst_gridinfo.tif'),
-    })
+    info = info_mock(
+        {
+            'dst_nu_file': 'testing/5by5.nc',
+            'dst_gridinfo': os.path.join(tmpdir, 'dst_gridinfo.tif'),
+        }
+    )
     create_wrf_gridinfo(info)
     assert os.listdir(tmpdir) == ['dst_gridinfo.tif']
     tif = rxr.open_rasterio(info.dst_gridinfo)
     assert tif.rio.crs.to_proj4() == '+init=epsg:4326'
     assert tif.rio.transform() == Affine(
-            0.01000213623046875, 0.0, -1.4050254821777344,
-            0.0, 0.010000228881835938, 41.480000495910645,
+        0.01000213623046875,
+        0.0,
+        -1.4050254821777344,
+        0.0,
+        0.010000228881835938,
+        41.480000495910645,
     )
+
 
 def test_get_SW_BW():
 
-    ucp_table = pd.read_csv(
-        'w2w/resources/LCZ_UCP_lookup.csv',
-         index_col=0
-    )
+    ucp_table = pd.read_csv('w2w/resources/LCZ_UCP_lookup.csv', index_col=0)
 
     SW, BW = _get_SW_BW(ucp_table)
 
     assert approx(list(SW[:10])) == [
-        20.0, 14.0, 5.2, 50.0, 35.0,
-        13.0, 3.333333, 32.5, 43.333333, 28.571428
+        20.0,
+        14.0,
+        5.2,
+        50.0,
+        35.0,
+        13.0,
+        3.333333,
+        32.5,
+        43.333333,
+        28.571428,
     ]
     assert approx(list(BW[:10])) == [
-        22.222222, 22.0, 9.533333, 42.857142, 26.25,
-        13.0, 25.0, 28.888888, 43.333333, 23.809523
+        22.222222,
+        22.0,
+        9.533333,
+        42.857142,
+        26.25,
+        13.0,
+        25.0,
+        28.888888,
+        43.333333,
+        23.809523,
     ]
+
 
 def test_get_lcz_arr(info_mock):
 
-    info = info_mock({
-        'src_file': 'sample_data/lcz_zaragoza.tif',
-        'BUILT_LCZ': [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
-    })
+    info = info_mock(
+        {
+            'src_file': 'sample_data/lcz_zaragoza.tif',
+            'BUILT_LCZ': [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+        }
+    )
 
     # Read gridded data: LCZ and WRF grid
     src_data = rxr.open_rasterio(info.src_file)[0, :, :]
 
-    lcz_arr = _get_lcz_arr(
-        src_data=src_data,
-        info=info
-    )
+    lcz_arr = _get_lcz_arr(src_data=src_data, info=info)
 
     # Make sure shape is fine
     assert lcz_arr.shape == (765, 1210)
@@ -314,17 +365,16 @@ def test_get_lcz_arr(info_mock):
     ),
 )
 def test_ucp_resampler_output_values_per_paramater(
-        ucp_key,
-        data_sum,
-        data_mean,
-        info_mock
+    ucp_key, data_sum, data_mean, info_mock
 ):
-    info = info_mock({
-        'src_file': 'sample_data/lcz_zaragoza.tif',
-        'src_file_clean': 'testing/lcz_zaragoza_clean.tif',
-        'dst_gridinfo': 'testing/geo_em.d04_gridinfo.tif',
-        'BUILT_LCZ': [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
-    })
+    info = info_mock(
+        {
+            'src_file': 'sample_data/lcz_zaragoza.tif',
+            'src_file_clean': 'testing/lcz_zaragoza_clean.tif',
+            'dst_gridinfo': 'testing/geo_em.d04_gridinfo.tif',
+            'BUILT_LCZ': [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+        }
+    )
     ucp_table = pd.read_csv('w2w/resources/LCZ_UCP_lookup.csv', index_col=0)
     ucp_res = _ucp_resampler(
         info=info,
@@ -340,13 +390,16 @@ def test_ucp_resampler_output_values_per_paramater(
     # Make sure no nans are present.
     np.sum(np.isnan(ucp_res.data)) == 0
 
+
 def test_ucp_resampler_output_values_per_paramater_frc_threshold(info_mock):
-    info = info_mock({
-        'src_file': 'sample_data/lcz_zaragoza.tif',
-        'src_file_clean': 'testing/lcz_zaragoza_clean.tif',
-        'dst_gridinfo': 'testing/geo_em.d04_gridinfo.tif',
-        'BUILT_LCZ': [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
-    })
+    info = info_mock(
+        {
+            'src_file': 'sample_data/lcz_zaragoza.tif',
+            'src_file_clean': 'testing/lcz_zaragoza_clean.tif',
+            'dst_gridinfo': 'testing/geo_em.d04_gridinfo.tif',
+            'BUILT_LCZ': [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+        }
+    )
     ucp_table = pd.read_csv('w2w/resources/LCZ_UCP_lookup.csv', index_col=0)
     ucp_res = _ucp_resampler(
         info=info,
@@ -363,19 +416,19 @@ def test_ucp_resampler_output_values_per_paramater_frc_threshold(info_mock):
     # Make sure no nans are present.
     np.sum(np.isnan(ucp_res.data)) == 0
 
+
 def test_hgt_resampler_output_values(info_mock):
 
-    info = info_mock({
-        'src_file': 'sample_data/lcz_zaragoza.tif',
-        'src_file_clean': 'testing/lcz_zaragoza_clean.tif',
-        'dst_gridinfo': 'testing/geo_em.d04_gridinfo.tif',
-        'BUILT_LCZ': [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
-    })
-
-    ucp_table = pd.read_csv(
-        'w2w/resources/LCZ_UCP_lookup.csv',
-         index_col=0
+    info = info_mock(
+        {
+            'src_file': 'sample_data/lcz_zaragoza.tif',
+            'src_file_clean': 'testing/lcz_zaragoza_clean.tif',
+            'dst_gridinfo': 'testing/geo_em.d04_gridinfo.tif',
+            'BUILT_LCZ': [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+        }
     )
+
+    ucp_table = pd.read_csv('w2w/resources/LCZ_UCP_lookup.csv', index_col=0)
 
     ucp_res = _hgt_resampler(
         info=info,
@@ -393,34 +446,30 @@ def test_hgt_resampler_output_values(info_mock):
     # Make sure no nans are present.
     assert np.sum(np.isnan(ucp_res.data)) == 0
 
+
 def test_check_hi_values_fails_skewed_distribution_ucp_table(capsys):
 
     lcz_i = 1
     SAMPLE_SIZE = 100000
-    ERROR_MARGIN=0.05
+    ERROR_MARGIN = 0.05
 
     # create dummpy ucp_table, with skewed distribution
     ucp_table = pd.DataFrame(
-        index = [1],
-        columns = ['MH_URB2D_MIN', 'MH_URB2D_MAX', 'MH_URB2D']
+        index=[1], columns=['MH_URB2D_MIN', 'MH_URB2D_MAX', 'MH_URB2D']
     )
     ucp_table.loc[1] = [5, 150, 40]
 
     hi_sample = _get_truncated_normal_sample(
-        lcz_i=lcz_i,
-        ucp_table=ucp_table,
-        SAMPLE_SIZE=SAMPLE_SIZE
+        lcz_i=lcz_i, ucp_table=ucp_table, SAMPLE_SIZE=SAMPLE_SIZE
     )
     assert len(hi_sample) == SAMPLE_SIZE
 
     _check_hi_values(
-        lcz_i=lcz_i,
-        hi_sample=hi_sample,
-        ucp_table=ucp_table,
-        ERROR_MARGIN=ERROR_MARGIN)
+        lcz_i=lcz_i, hi_sample=hi_sample, ucp_table=ucp_table, ERROR_MARGIN=ERROR_MARGIN
+    )
     out, _ = capsys.readouterr()
-    assert 'distribution not in expected range (5.0% marging) ' \
-           'for LCZ class 1' in out
+    assert 'distribution not in expected range (5.0% marging) ' 'for LCZ class 1' in out
+
 
 def test_check_hi_values_fails_sample_size_too_small(capsys):
 
@@ -428,24 +477,18 @@ def test_check_hi_values_fails_sample_size_too_small(capsys):
     SAMPLE_SIZE = 10
     ERROR_MARGIN = 0.05
 
-    ucp_table = pd.read_csv(
-        'w2w/resources/LCZ_UCP_lookup.csv',
-         index_col=0
-    )
+    ucp_table = pd.read_csv('w2w/resources/LCZ_UCP_lookup.csv', index_col=0)
 
     hi_sample = _get_truncated_normal_sample(
-        lcz_i=lcz_i,
-        ucp_table=ucp_table,
-        SAMPLE_SIZE=SAMPLE_SIZE
+        lcz_i=lcz_i, ucp_table=ucp_table, SAMPLE_SIZE=SAMPLE_SIZE
     )
 
     _check_hi_values(
-        lcz_i=lcz_i,
-        hi_sample=hi_sample,
-        ucp_table=ucp_table,
-        ERROR_MARGIN=ERROR_MARGIN)
+        lcz_i=lcz_i, hi_sample=hi_sample, ucp_table=ucp_table, ERROR_MARGIN=ERROR_MARGIN
+    )
     out, _ = capsys.readouterr()
     assert 'distribution not in expected range' in out
+
 
 def test_check_hi_values_fails_error_margin_too_small(capsys):
 
@@ -453,33 +496,24 @@ def test_check_hi_values_fails_error_margin_too_small(capsys):
     SAMPLE_SIZE = 100000
     ERROR_MARGIN = 0.000001
 
-    ucp_table = pd.read_csv(
-        'w2w/resources/LCZ_UCP_lookup.csv',
-         index_col=0
-    )
+    ucp_table = pd.read_csv('w2w/resources/LCZ_UCP_lookup.csv', index_col=0)
 
     hi_sample = _get_truncated_normal_sample(
-        lcz_i=lcz_i,
-        ucp_table=ucp_table,
-        SAMPLE_SIZE=SAMPLE_SIZE
+        lcz_i=lcz_i, ucp_table=ucp_table, SAMPLE_SIZE=SAMPLE_SIZE
     )
 
     _check_hi_values(
-        lcz_i=lcz_i,
-        hi_sample=hi_sample,
-        ucp_table=ucp_table,
-        ERROR_MARGIN=ERROR_MARGIN)
+        lcz_i=lcz_i, hi_sample=hi_sample, ucp_table=ucp_table, ERROR_MARGIN=ERROR_MARGIN
+    )
     out, _ = capsys.readouterr()
     assert 'distribution not in expected range' in out
+
 
 def test_compute_hi_distribution_values(info_mock):
 
     info = info_mock({'BUILT_LCZ': [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]})
 
-    ucp_table = pd.read_csv(
-        'w2w/resources/LCZ_UCP_lookup.csv',
-         index_col=0
-    )
+    ucp_table = pd.read_csv('w2w/resources/LCZ_UCP_lookup.csv', index_col=0)
     SAMPLE_SIZE = 100000
     ERROR_MARGIN = 0.05
 
@@ -496,16 +530,14 @@ def test_compute_hi_distribution_values(info_mock):
     # Natural LCZ classes should have all 0
     value, counts = np.unique(df_hi.loc[range(11, 18, 1)].values, return_counts=True)
     assert value[0] == 0
-    assert counts[0] == 7*15 # 7 Natural LCZs x 15 height bins
+    assert counts[0] == 7 * 15  # 7 Natural LCZs x 15 height bins
+
 
 def test_compute_hi_distribution_values_lcz15(info_mock):
 
     info = info_mock({'BUILT_LCZ': [15]})
 
-    ucp_table = pd.read_csv(
-        'w2w/resources/LCZ_UCP_lookup.csv',
-         index_col=0
-    )
+    ucp_table = pd.read_csv('w2w/resources/LCZ_UCP_lookup.csv', index_col=0)
     SAMPLE_SIZE = 100000
     ERROR_MARGIN = 0.05
 
@@ -520,6 +552,7 @@ def test_compute_hi_distribution_values_lcz15(info_mock):
     # across all height bins should be 0.
     assert df_hi.iloc[15].fillna(0).sum() == 0
 
+
 def test_scale_hi():
 
     # Create random array to work with,
@@ -530,15 +563,18 @@ def test_scale_hi():
     a_scaled = np.apply_along_axis(_scale_hi, 0, a)
 
     # Check that all pixels sum to 100
-    assert np.full((5, 5), 100.) == approx((np.sum(a_scaled, axis=0)))
+    assert np.full((5, 5), 100.0) == approx((np.sum(a_scaled, axis=0)))
+
 
 def test_hi_resampler(info_mock):
 
-    info = info_mock({
-        'src_file_clean': 'testing/lcz_zaragoza_clean.tif',
-        'dst_gridinfo': 'testing/geo_em.d04_gridinfo.tif',
-        'BUILT_LCZ': [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
-    })
+    info = info_mock(
+        {
+            'src_file_clean': 'testing/lcz_zaragoza_clean.tif',
+            'dst_gridinfo': 'testing/geo_em.d04_gridinfo.tif',
+            'BUILT_LCZ': [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+        }
+    )
 
     ucp_table = pd.read_csv('w2w/resources/LCZ_UCP_lookup.csv', index_col=0)
 
@@ -566,29 +602,34 @@ def test_hi_resampler(info_mock):
 @pytest.mark.parametrize(
     ('LCZ_NAT_MASK', 'lcz_values', 'lcz_counts'),
     (
-        (False,
-         np.array([32., 33., 35., 36., 38., 39., 41., 42., 43., 44., 46.]),
-         np.array([ 17,   3,   1,  77,  95,   2,   7,   5,   2, 150,  10]),
-         ),
-        (True,
-         np.array([32., 33., 35., 36., 38., 39., 41.]),
-         np.array([ 18,  30,   1, 171, 136,   4,   9]),
-         ),
+        (
+            False,
+            np.array(
+                [32.0, 33.0, 35.0, 36.0, 38.0, 39.0, 41.0, 42.0, 43.0, 44.0, 46.0]
+            ),
+            np.array([17, 3, 1, 77, 95, 2, 7, 5, 2, 150, 10]),
+        ),
+        (
+            True,
+            np.array([32.0, 33.0, 35.0, 36.0, 38.0, 39.0, 41.0]),
+            np.array([18, 30, 1, 171, 136, 4, 9]),
+        ),
     ),
 )
-
 def test_lcz_resampler_lcz_nat_mask_on_off_with_lcz15(
-        LCZ_NAT_MASK,
-        lcz_values,
-        lcz_counts,
-        info_mock,
+    LCZ_NAT_MASK,
+    lcz_values,
+    lcz_counts,
+    info_mock,
 ):
 
-    info = info_mock({
-        'src_file_clean': 'testing/lcz_zaragoza_clean.tif',
-        'dst_gridinfo': 'testing/geo_em.d04_gridinfo.tif',
-        'BUILT_LCZ': [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 15],
-    })
+    info = info_mock(
+        {
+            'src_file_clean': 'testing/lcz_zaragoza_clean.tif',
+            'dst_gridinfo': 'testing/geo_em.d04_gridinfo.tif',
+            'BUILT_LCZ': [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 15],
+        }
+    )
 
     frc_data = xr.open_dataset('testing/geo_em.d04_LCZ_params_no_urb_param.nc')
     frc_urb2d = frc_data['FRC_URB2D']
@@ -604,23 +645,26 @@ def test_lcz_resampler_lcz_nat_mask_on_off_with_lcz15(
     assert (lcz_values_def == lcz_values).all()
     assert (lcz_counts_def == lcz_counts).all()
 
+
 def test_add_frc_lu_index_2_wrf(info_mock):
 
-    info = info_mock({
-        'src_file_clean': 'testing/lcz_zaragoza_clean.tif',
-        'dst_file': 'sample_data/geo_em.d04.nc',
-        'dst_nu_file': 'testing/geo_em.d04_NoUrban.nc',
-        'dst_gridinfo': 'testing/geo_em.d04_gridinfo.tif',
-        'BUILT_LCZ': [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
-    })
+    info = info_mock(
+        {
+            'src_file_clean': 'testing/lcz_zaragoza_clean.tif',
+            'dst_file': 'sample_data/geo_em.d04.nc',
+            'dst_nu_file': 'testing/geo_em.d04_NoUrban.nc',
+            'dst_gridinfo': 'testing/geo_em.d04_gridinfo.tif',
+            'BUILT_LCZ': [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+        }
+    )
 
     ucp_table = pd.read_csv('w2w/resources/LCZ_UCP_lookup.csv', index_col=0)
 
     dst_data = _add_frc_lu_index_2_wrf(
-        info = info,
-        FRC_THRESHOLD = 0.2,
-        LCZ_NAT_MASK = True,
-        ucp_table = ucp_table,
+        info=info,
+        FRC_THRESHOLD=0.2,
+        LCZ_NAT_MASK=True,
+        ucp_table=ucp_table,
     )
 
     # LU_Index should be expanded, reflecting LCZ classes between 31-41.
@@ -633,36 +677,39 @@ def test_add_frc_lu_index_2_wrf(info_mock):
     # GREENFRAC is adjusted, because of LCZ implementation
     # Can be - or +, depending on conversion natural to LCZ land.
     dst_nu = xr.open_dataset(info.dst_nu_file)
-    assert (dst_data['GREENFRAC'][0,:,:,:].mean(axis=0) -
-            dst_nu['GREENFRAC'][0,:,:,:].mean(axis=0)).data.min() == approx(-0.193724)
-    assert (dst_data['GREENFRAC'][0,:,:,:].mean(axis=0) -
-            dst_nu['GREENFRAC'][0,:,:,:].mean(axis=0)).data.max() == approx(0.31252602)
+    assert (
+        dst_data['GREENFRAC'][0, :, :, :].mean(axis=0)
+        - dst_nu['GREENFRAC'][0, :, :, :].mean(axis=0)
+    ).data.min() == approx(-0.193724)
+    assert (
+        dst_data['GREENFRAC'][0, :, :, :].mean(axis=0)
+        - dst_nu['GREENFRAC'][0, :, :, :].mean(axis=0)
+    ).data.max() == approx(0.31252602)
 
     # If done properly, the Landuse Fraction should still add up to 1 for all pixels
-    assert np.unique(dst_data['LANDUSEF'][0,:,:,:].sum(axis=0)) == np.array(1)
+    assert np.unique(dst_data['LANDUSEF'][0, :, :, :].sum(axis=0)) == np.array(1)
 
 
 @pytest.mark.parametrize(
     ('att_name', 'att_value'),
     (
         ('FieldType', np.intc(104)),
-        ('MemoryOrder', "XYZ"),
-        ('units', "dimensionless"),
-        ('description', "all urban parameters"),
-        ('stagger', "M"),
+        ('MemoryOrder', 'XYZ'),
+        ('units', 'dimensionless'),
+        ('description', 'all urban parameters'),
+        ('stagger', 'M'),
         ('sr_x', np.intc(1)),
         ('sr_y', np.intc(1)),
     ),
 )
 def test_initialize_urb_param(
-        att_name,
-        att_value,
+    att_name,
+    att_value,
 ):
     dst_data = xr.open_dataset('testing/geo_em.d04_LCZ_params_no_urb_param.nc')
 
     # Create the URB_PARAMS matrix
-    dst_final = _initialize_urb_param(
-        dst_data=dst_data)
+    dst_final = _initialize_urb_param(dst_data=dst_data)
 
     # Check size of URB_PARAM
     assert dst_final['URB_PARAM'].shape == (1, 132, 102, 162)
@@ -670,21 +717,22 @@ def test_initialize_urb_param(
     # All attributes available?
     assert dst_final['URB_PARAM'].attrs[att_name] == att_value
 
+
 @pytest.mark.parametrize(
     ('att_name', 'att_value'),
     (
         ('NUM_LAND_CAT', 41),
         ('FLAG_URB_PARAM', 1),
         ('NBUI_MAX', np.intc(5)),
-        ('TITLE', "OUTPUT FROM GEOGRID V4.0, perturbed by W2W"),
+        ('TITLE', 'OUTPUT FROM GEOGRID V4.0, perturbed by W2W'),
     ),
 )
 def test_create_lcz_params_file_attrs_type(
-        att_name,
-        att_value,
-        tmpdir,
-        capsys,
-        info_mock,
+    att_name,
+    att_value,
+    tmpdir,
+    capsys,
+    info_mock,
 ):
     input_dir = tmpdir.mkdir('input')
     shutil.copy(os.path.join('sample_data', 'geo_em.d04.nc'), input_dir)
@@ -692,28 +740,25 @@ def test_create_lcz_params_file_attrs_type(
     shutil.copy(os.path.join('testing', 'geo_em.d04_gridinfo.tif'), input_dir)
     shutil.copy(os.path.join('testing', 'geo_em.d04_NoUrban.nc'), input_dir)
 
-    info = info_mock({
-        'src_file_clean': os.path.join(input_dir, 'lcz_zaragoza_clean.tif'),
-        'dst_file': os.path.join(input_dir, 'geo_em.d04.nc'),
-        'dst_nu_file': os.path.join(input_dir, 'geo_em.d04_NoUrban.nc'),
-        'dst_gridinfo': os.path.join(input_dir, 'geo_em.d04_gridinfo.tif'),
-        'dst_lcz_params_file': os.path.join(input_dir, 'geo_em.d04_LCZ_params.tif'),
-        'BUILT_LCZ': [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
-    })
-
-    ucp_table = pd.read_csv(
-        'w2w/resources/LCZ_UCP_lookup.csv',
-         index_col=0
+    info = info_mock(
+        {
+            'src_file_clean': os.path.join(input_dir, 'lcz_zaragoza_clean.tif'),
+            'dst_file': os.path.join(input_dir, 'geo_em.d04.nc'),
+            'dst_nu_file': os.path.join(input_dir, 'geo_em.d04_NoUrban.nc'),
+            'dst_gridinfo': os.path.join(input_dir, 'geo_em.d04_gridinfo.tif'),
+            'dst_lcz_params_file': os.path.join(input_dir, 'geo_em.d04_LCZ_params.tif'),
+            'BUILT_LCZ': [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+        }
     )
+
+    ucp_table = pd.read_csv('w2w/resources/LCZ_UCP_lookup.csv', index_col=0)
 
     # Copy file, as dummy for LCZ_params.nc
     shutil.copy(info.dst_file, info.dst_lcz_params_file)
 
     nbui_max = create_lcz_params_file(
-        info=info,
-        FRC_THRESHOLD=0.2,
-        LCZ_NAT_MASK=True,
-        ucp_table=ucp_table)
+        info=info, FRC_THRESHOLD=0.2, LCZ_NAT_MASK=True, ucp_table=ucp_table
+    )
     out, _ = capsys.readouterr()
 
     # Check that output file is written
@@ -730,21 +775,21 @@ def test_create_lcz_params_file_attrs_type(
     # Check if nbui_max has expected value
     assert nbui_max == 5
 
-def test_create_lcz_extent_file(tmpdir, info_mock):
-    info = info_mock({
-        'src_file_clean': 'testing/lcz_zaragoza_clean.tif',
-        'dst_lcz_params_file': 'testing/geo_em.d04_LCZ_params.nc',
-        'dst_lcz_extent_file': os.path.join(tmpdir,'geo_em.d04_LCZ_extent.nc'),
-        'dst_file': 'sample_data/geo_em.d04.nc',
-        'dst_nu_file': 'testing/geo_em.d04_NoUrban.nc',
-        'dst_gridinfo': 'testing/geo_em.d04_gridinfo.tif',
-        'BUILT_LCZ': [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
-    })
 
-    ucp_table = pd.read_csv(
-        'w2w/resources/LCZ_UCP_lookup.csv',
-         index_col=0
+def test_create_lcz_extent_file(tmpdir, info_mock):
+    info = info_mock(
+        {
+            'src_file_clean': 'testing/lcz_zaragoza_clean.tif',
+            'dst_lcz_params_file': 'testing/geo_em.d04_LCZ_params.nc',
+            'dst_lcz_extent_file': os.path.join(tmpdir, 'geo_em.d04_LCZ_extent.nc'),
+            'dst_file': 'sample_data/geo_em.d04.nc',
+            'dst_nu_file': 'testing/geo_em.d04_NoUrban.nc',
+            'dst_gridinfo': 'testing/geo_em.d04_gridinfo.tif',
+            'BUILT_LCZ': [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+        }
     )
+
+    ucp_table = pd.read_csv('w2w/resources/LCZ_UCP_lookup.csv', index_col=0)
 
     frc_mask = _add_frc_lu_index_2_wrf(
         info=info,
@@ -764,13 +809,16 @@ def test_create_lcz_extent_file(tmpdir, info_mock):
     # Check perturbations applied to LCZ_params file
     assert dst_extent.attrs['FLAG_URB_PARAM'] == np.intc(0)
     assert dst_extent.attrs['NUM_LAND_CAT'] == 41
-    assert dst_extent.LANDUSEF.description == \
-           'Noah-modified 21-category IGBP-MODIS landuse'
+    assert (
+        dst_extent.LANDUSEF.description
+        == 'Noah-modified 21-category IGBP-MODIS landuse'
+    )
     assert 'FRC_URB2D' not in list(dst_extent.data_vars)
     assert 'URB_PARAM' not in list(dst_extent.data_vars)
 
     # Number of urban pixels within LANDUSEF[12]
     assert np.sum(dst_extent['LANDUSEF'].data[0, 12, :, :] == 1) == 369
+
 
 @pytest.mark.parametrize(
     ('domain_id'),
@@ -782,81 +830,99 @@ def test_create_lcz_extent_file(tmpdir, info_mock):
 )
 def test_expand_land_cat_parents_files_missing(domain_id, capsys, tmpdir, info_mock):
     ifiles = (
-        'geo_em.d04.nc', 'lcz_zaragoza_clean.tif',
+        'geo_em.d04.nc',
+        'lcz_zaragoza_clean.tif',
     )
     input_dir = tmpdir.mkdir('input')
     shutil.copy(os.path.join('sample_data', ifiles[0]), input_dir)
     shutil.copy(os.path.join('testing', ifiles[1]), input_dir)
 
-    info = info_mock({
-        'dst_file': os.path.join(input_dir, 'geo_em.d04.nc'),
-        'io_dir': 'SOME_DIRECTORY',
-    })
+    info = info_mock(
+        {
+            'dst_file': os.path.join(input_dir, 'geo_em.d04.nc'),
+            'io_dir': 'SOME_DIRECTORY',
+        }
+    )
 
     expand_land_cat_parents(info=info)
     out, _ = capsys.readouterr()
 
-    warning_str = f"WARNING: Parent domain {info.dst_file[:-5]}{domain_id}.nc not found"
+    warning_str = f'WARNING: Parent domain {info.dst_file[:-5]}{domain_id}.nc not found'
     assert warning_str in out
+
 
 def test_expand_land_cat_parents_no_num_land_cat(tmpdir, capsys, info_mock):
     input_dir = tmpdir.mkdir('input')
-    shutil.copy(os.path.join('testing', 'geo_em.d02_Shanghai.nc'),
-                os.path.join(input_dir,'geo_em.d02.nc')
-                )
-    shutil.copy(os.path.join('testing', 'geo_em.d01_Shanghai_no_NUM_LAND_CAT.nc'),
-                os.path.join(input_dir,'geo_em.d01.nc')
-                )
-    info = info_mock({
-        'dst_file' : os.path.join(input_dir,'geo_em.d02.nc'),
-        'io_dir': 'some_dummy_directory'
-    })
+    shutil.copy(
+        os.path.join('testing', 'geo_em.d02_Shanghai.nc'),
+        os.path.join(input_dir, 'geo_em.d02.nc'),
+    )
+    shutil.copy(
+        os.path.join('testing', 'geo_em.d01_Shanghai_no_NUM_LAND_CAT.nc'),
+        os.path.join(input_dir, 'geo_em.d01.nc'),
+    )
+    info = info_mock(
+        {
+            'dst_file': os.path.join(input_dir, 'geo_em.d02.nc'),
+            'io_dir': 'some_dummy_directory',
+        }
+    )
     expand_land_cat_parents(
         info=info,
     )
     out, _ = capsys.readouterr()
-    warning_str = f"Cannot read NUM_LAND_CAT"
+    warning_str = f'Cannot read NUM_LAND_CAT'
     assert warning_str in out
 
 
 def test_expand_land_cat_parents_num_land_cat_41(capsys, tmpdir, info_mock):
 
     input_dir = tmpdir.mkdir('input')
-    shutil.copy(os.path.join('testing', 'geo_em.d02_Shanghai.nc'),
-                os.path.join(input_dir,'geo_em.d02.nc')
-                )
-    shutil.copy(os.path.join('testing', 'geo_em.d01_Shanghai_ncl41.nc'),
-                os.path.join(input_dir,'geo_em.d01.nc')
-                )
-    info = info_mock({
-        'dst_file' : os.path.join(input_dir,'geo_em.d02.nc'),
-        'io_dir': 'some_dummy_directory'
-    })
+    shutil.copy(
+        os.path.join('testing', 'geo_em.d02_Shanghai.nc'),
+        os.path.join(input_dir, 'geo_em.d02.nc'),
+    )
+    shutil.copy(
+        os.path.join('testing', 'geo_em.d01_Shanghai_ncl41.nc'),
+        os.path.join(input_dir, 'geo_em.d01.nc'),
+    )
+    info = info_mock(
+        {
+            'dst_file': os.path.join(input_dir, 'geo_em.d02.nc'),
+            'io_dir': 'some_dummy_directory',
+        }
+    )
     expand_land_cat_parents(
         info=info,
     )
     out, _ = capsys.readouterr()
     assert 'already contains 41 LC classes' in out
 
+
 def test_expand_land_cat_parents_num_land_cat_not41(capsys, tmpdir, info_mock):
 
     input_dir = tmpdir.mkdir('input')
-    shutil.copy(os.path.join('testing', 'geo_em.d02_Shanghai.nc'),
-                os.path.join(input_dir,'geo_em.d02.nc')
-                )
-    shutil.copy(os.path.join('testing', 'geo_em.d01_Shanghai_ncl20.nc'),
-                os.path.join(input_dir,'geo_em.d01.nc')
-                )
-    info = info_mock({
-        'dst_file' : os.path.join(input_dir,'geo_em.d02.nc'),
-        'io_dir': 'some_dummy_directory'
-    })
+    shutil.copy(
+        os.path.join('testing', 'geo_em.d02_Shanghai.nc'),
+        os.path.join(input_dir, 'geo_em.d02.nc'),
+    )
+    shutil.copy(
+        os.path.join('testing', 'geo_em.d01_Shanghai_ncl20.nc'),
+        os.path.join(input_dir, 'geo_em.d01.nc'),
+    )
+    info = info_mock(
+        {
+            'dst_file': os.path.join(input_dir, 'geo_em.d02.nc'),
+            'io_dir': 'some_dummy_directory',
+        }
+    )
     expand_land_cat_parents(
         info=info,
     )
     out, _ = capsys.readouterr()
     contents = os.listdir(input_dir)
     assert 'geo_em.d01_41.nc' in contents
+
 
 def test_checks_and_cleaning_sample_data_all_ok(capsys, tmpdir, info_mock):
 
@@ -868,86 +934,99 @@ def test_checks_and_cleaning_sample_data_all_ok(capsys, tmpdir, info_mock):
     shutil.copy(os.path.join('testing', 'geo_em.d04_LCZ_extent.nc'), input_dir)
     shutil.copy(os.path.join('testing', 'geo_em.d04_LCZ_params.nc'), input_dir)
 
-    info = info_mock({
-        'src_file_clean': os.path.join(input_dir, 'lcz_zaragoza_clean.tif'),
-        'dst_file': os.path.join(input_dir, 'geo_em.d04.nc'),
-        'dst_nu_file': os.path.join(input_dir, 'geo_em.d04_NoUrban.nc'),
-        'dst_gridinfo': os.path.join(input_dir, 'geo_em.d04_gridinfo.tif'),
-        'dst_lcz_extent_file': os.path.join(input_dir, 'geo_em.d04_LCZ_extent.nc'),
-        'dst_lcz_params_file': os.path.join(input_dir, 'geo_em.d04_LCZ_params.nc'),
-        'BUILT_LCZ': [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
-    })
-
-    ucp_table = pd.read_csv(
-        'w2w/resources/LCZ_UCP_lookup.csv',
-         index_col=0
+    info = info_mock(
+        {
+            'src_file_clean': os.path.join(input_dir, 'lcz_zaragoza_clean.tif'),
+            'dst_file': os.path.join(input_dir, 'geo_em.d04.nc'),
+            'dst_nu_file': os.path.join(input_dir, 'geo_em.d04_NoUrban.nc'),
+            'dst_gridinfo': os.path.join(input_dir, 'geo_em.d04_gridinfo.tif'),
+            'dst_lcz_extent_file': os.path.join(input_dir, 'geo_em.d04_LCZ_extent.nc'),
+            'dst_lcz_params_file': os.path.join(input_dir, 'geo_em.d04_LCZ_params.nc'),
+            'BUILT_LCZ': [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+        }
     )
+
+    ucp_table = pd.read_csv('w2w/resources/LCZ_UCP_lookup.csv', index_col=0)
 
     NBUI_MAX = 5
 
-    OKGREEN = "\033[0;32m"
+    OKGREEN = '\033[0;32m'
 
-    checks_and_cleaning(
-        info=info,
-        ucp_table=ucp_table,
-        nbui_max=NBUI_MAX
-    )
+    checks_and_cleaning(info=info, ucp_table=ucp_table, nbui_max=NBUI_MAX)
     out, _ = capsys.readouterr()
 
     # Check the outcome of the sample data, for which all is fine.
-    base_text = f"> Check 1: Urban class removed from " \
-          f"{info.dst_nu_file.split('/')[-1]}?"
-    check1 = f"{base_text}{OKGREEN} OK"
+    base_text = (
+        f'> Check 1: Urban class removed from ' f"{info.dst_nu_file.split('/')[-1]}?"
+    )
+    check1 = f'{base_text}{OKGREEN} OK'
     assert check1 in out
 
-    base_text = f"> Check 2: LCZ Urban extent present in " \
-          f"{info.dst_lcz_extent_file.split('/')[-1]}?"
-    check2 = f"{base_text}{OKGREEN} OK"
+    base_text = (
+        f'> Check 2: LCZ Urban extent present in '
+        f"{info.dst_lcz_extent_file.split('/')[-1]}?"
+    )
+    check2 = f'{base_text}{OKGREEN} OK'
     assert check2 in out
 
-    base_text = f"> Check 3: Urban LCZ classes exists in " \
-                f"{info.dst_lcz_params_file.split('/')[-1]}?"
-    check3 = f"{base_text}{OKGREEN} OK: LCZ Classes"
+    base_text = (
+        f'> Check 3: Urban LCZ classes exists in '
+        f"{info.dst_lcz_params_file.split('/')[-1]}?"
+    )
+    check3 = f'{base_text}{OKGREEN} OK: LCZ Classes'
     assert check3 in out
 
-    base_text = f"> Check 4: FRC_URB2D present in " \
-          f"{info.dst_lcz_params_file.split('/')[-1]}?"
-    check4 = f"{base_text}{OKGREEN} OK: FRC_URB2D values "
+    base_text = (
+        f'> Check 4: FRC_URB2D present in '
+        f"{info.dst_lcz_params_file.split('/')[-1]}?"
+    )
+    check4 = f'{base_text}{OKGREEN} OK: FRC_URB2D values '
     assert check4 in out
 
-    base_text = f"> Check 5: URB_PARAMS matrix present in file " \
-          f"{info.dst_lcz_params_file.split('/')[-1]}?"
-    check5 = f"{base_text}{OKGREEN} OK "
+    base_text = (
+        f'> Check 5: URB_PARAMS matrix present in file '
+        f"{info.dst_lcz_params_file.split('/')[-1]}?"
+    )
+    check5 = f'{base_text}{OKGREEN} OK '
     assert check5 in out
 
-    base_text = "> Check 6: Do URB_PARAM variable values follow expected range in " \
-          f"{info.dst_lcz_params_file.split('/')[-1]}?"
-    check6a = f"{base_text}"
-    check6b = f"{OKGREEN}   + OK for"
+    base_text = (
+        '> Check 6: Do URB_PARAM variable values follow expected range in '
+        f"{info.dst_lcz_params_file.split('/')[-1]}?"
+    )
+    check6a = f'{base_text}'
+    check6b = f'{OKGREEN}   + OK for'
     assert check6a in out
     assert check6b in out
 
-    base_text = "> Check 7: Does HI_URB2D sum to 100% for urban pixels " \
-          f"in {info.dst_lcz_params_file.split('/')[-1]}?"
-    check7 = f"{base_text}{OKGREEN} OK"
+    base_text = (
+        '> Check 7: Does HI_URB2D sum to 100% for urban pixels '
+        f"in {info.dst_lcz_params_file.split('/')[-1]}?"
+    )
+    check7 = f'{base_text}{OKGREEN} OK'
     assert check7 in out
 
-    base_text = "> Check 8: Do FRC_URB and LCZs (from LU_INDEX) cover same extent " \
-          f"in {info.dst_lcz_params_file.split('/')[-1]}?"
-    check8 = f"{base_text}{OKGREEN} OK"
+    base_text = (
+        '> Check 8: Do FRC_URB and LCZs (from LU_INDEX) cover same extent '
+        f"in {info.dst_lcz_params_file.split('/')[-1]}?"
+    )
+    check8 = f'{base_text}{OKGREEN} OK'
     assert check8 in out
 
-    base_text = "> Check 9: Extent and # urban pixels same for " \
-          "*_extent.nc and *_params.nc output file?"
-    check9 = f"{base_text}{OKGREEN} OK, urban extent the same "
+    base_text = (
+        '> Check 9: Extent and # urban pixels same for '
+        '*_extent.nc and *_params.nc output file?'
+    )
+    check9 = f'{base_text}{OKGREEN} OK, urban extent the same '
     assert check9 in out
 
-    assert f" Set nbui_max to {NBUI_MAX} during compilation, " in out
+    assert f' Set nbui_max to {NBUI_MAX} during compilation, ' in out
+
 
 def test_checks_and_cleaning_sample_data_check1to5_wrong(
-        capsys,
-        tmpdir,
-        info_mock,
+    capsys,
+    tmpdir,
+    info_mock,
 ):
 
     # Test WARNINGS by using dummy lcz_extent and lcz_params files
@@ -960,47 +1039,47 @@ def test_checks_and_cleaning_sample_data_check1to5_wrong(
     shutil.copy(os.path.join('testing', 'geo_em.d04_LCZ_extent_dummy.nc'), input_dir)
     shutil.copy(os.path.join('testing', 'geo_em.d04_LCZ_params_dummy.nc'), input_dir)
 
-    info = info_mock({
-        'src_file_clean': os.path.join(input_dir, 'lcz_zaragoza_clean.tif'),
-        'dst_file': os.path.join(input_dir, 'geo_em.d04.nc'),
-        'dst_nu_file': os.path.join(input_dir, 'geo_em.d04_NoUrban_dummy.nc'),
-        'dst_gridinfo': os.path.join(input_dir, 'geo_em.d04_gridinfo.tif'),
-        'dst_lcz_extent_file': os.path.join(input_dir, 'geo_em.d04_LCZ_extent_dummy.nc'),
-        'dst_lcz_params_file': os.path.join(input_dir, 'geo_em.d04_LCZ_params_dummy.nc'),
-        'BUILT_LCZ': [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
-    })
-
-    ucp_table = pd.read_csv(
-        'w2w/resources/LCZ_UCP_lookup.csv',
-         index_col=0
+    info = info_mock(
+        {
+            'src_file_clean': os.path.join(input_dir, 'lcz_zaragoza_clean.tif'),
+            'dst_file': os.path.join(input_dir, 'geo_em.d04.nc'),
+            'dst_nu_file': os.path.join(input_dir, 'geo_em.d04_NoUrban_dummy.nc'),
+            'dst_gridinfo': os.path.join(input_dir, 'geo_em.d04_gridinfo.tif'),
+            'dst_lcz_extent_file': os.path.join(
+                input_dir, 'geo_em.d04_LCZ_extent_dummy.nc'
+            ),
+            'dst_lcz_params_file': os.path.join(
+                input_dir, 'geo_em.d04_LCZ_params_dummy.nc'
+            ),
+            'BUILT_LCZ': [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+        }
     )
 
-    checks_and_cleaning(
-        info=info,
-        ucp_table=ucp_table,
-        nbui_max=5
-    )
+    ucp_table = pd.read_csv('w2w/resources/LCZ_UCP_lookup.csv', index_col=0)
+
+    checks_and_cleaning(info=info, ucp_table=ucp_table, nbui_max=5)
     out, _ = capsys.readouterr()
     # Check 1
-    assert "WARNING: Urban land use" in out
+    assert 'WARNING: Urban land use' in out
     # Check 2
-    assert "WARNING: LCZ-based urban" in out
+    assert 'WARNING: LCZ-based urban' in out
     # Check 3
-    assert "WARNING: Urban extent still" in out
+    assert 'WARNING: Urban extent still' in out
     # Check 4
-    assert "WARNING: FRC_URB2D not" in out
+    assert 'WARNING: FRC_URB2D not' in out
     # Check 5
-    assert "WARNING: URB_PARAM matrix not" in out
+    assert 'WARNING: URB_PARAM matrix not' in out
 
 
 @pytest.mark.parametrize(
-    'ucp_key', ('MH_URB2D', 'STDH_URB2D', 'LB_URB2D', 'LF_URB2D', 'LP_URB2D'),
+    'ucp_key',
+    ('MH_URB2D', 'STDH_URB2D', 'LB_URB2D', 'LF_URB2D', 'LP_URB2D'),
 )
 def test_checks_and_cleaning_sample_data_check6to9_wrong(
-        ucp_key,
-        capsys,
-        tmpdir,
-        info_mock,
+    ucp_key,
+    capsys,
+    tmpdir,
+    info_mock,
 ):
 
     # Test WARNINGS by using dummy lcz_extent and lcz_params files
@@ -1011,36 +1090,37 @@ def test_checks_and_cleaning_sample_data_check6to9_wrong(
     shutil.copy(os.path.join('testing', 'geo_em.d04_gridinfo.tif'), input_dir)
     shutil.copy(os.path.join('testing', 'geo_em.d04_NoUrban_dummy.nc'), input_dir)
     shutil.copy(os.path.join('testing', 'geo_em.d04_LCZ_extent_dummy.nc'), input_dir)
-    shutil.copy(os.path.join('testing', 'geo_em.d04_LCZ_params_with_ucp_dummy.nc'), input_dir)
-
-    info = info_mock({
-        'src_file_clean': os.path.join(input_dir, 'lcz_zaragoza_clean.tif'),
-        'dst_file': os.path.join(input_dir, 'geo_em.d04.nc'),
-        'dst_nu_file': os.path.join(input_dir, 'geo_em.d04_NoUrban_dummy.nc'),
-        'dst_gridinfo': os.path.join(input_dir, 'geo_em.d04_gridinfo.tif'),
-        'dst_lcz_extent_file': os.path.join(input_dir, 'geo_em.d04_LCZ_extent_dummy.nc'),
-        'dst_lcz_params_file': os.path.join(input_dir, 'geo_em.d04_LCZ_params_with_ucp_dummy.nc'),
-        'BUILT_LCZ': [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
-        })
-    ucp_table = pd.read_csv(
-        'w2w/resources/LCZ_UCP_lookup.csv',
-         index_col=0
+    shutil.copy(
+        os.path.join('testing', 'geo_em.d04_LCZ_params_with_ucp_dummy.nc'), input_dir
     )
 
-    checks_and_cleaning(
-        info=info,
-        ucp_table=ucp_table,
-        nbui_max=5
+    info = info_mock(
+        {
+            'src_file_clean': os.path.join(input_dir, 'lcz_zaragoza_clean.tif'),
+            'dst_file': os.path.join(input_dir, 'geo_em.d04.nc'),
+            'dst_nu_file': os.path.join(input_dir, 'geo_em.d04_NoUrban_dummy.nc'),
+            'dst_gridinfo': os.path.join(input_dir, 'geo_em.d04_gridinfo.tif'),
+            'dst_lcz_extent_file': os.path.join(
+                input_dir, 'geo_em.d04_LCZ_extent_dummy.nc'
+            ),
+            'dst_lcz_params_file': os.path.join(
+                input_dir, 'geo_em.d04_LCZ_params_with_ucp_dummy.nc'
+            ),
+            'BUILT_LCZ': [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+        }
     )
+    ucp_table = pd.read_csv('w2w/resources/LCZ_UCP_lookup.csv', index_col=0)
+
+    checks_and_cleaning(info=info, ucp_table=ucp_table, nbui_max=5)
     out, _ = capsys.readouterr()
     # Check 6
-    assert f"WARNING: {ucp_key} exceeds " in out
+    assert f'WARNING: {ucp_key} exceeds ' in out
     # Check 7
-    assert f"WARNING: Not all pixels " in out
+    assert f'WARNING: Not all pixels ' in out
     # Check 8
-    assert f"WARNING: FRC_URB and LCZs in " in out
+    assert f'WARNING: FRC_URB and LCZs in ' in out
     # Check 9
-    assert f"WARNING: Different # urban pixels (or extent) " in out
+    assert f'WARNING: Different # urban pixels (or extent) ' in out
 
 
 def test_main_with_example_data(tmpdir):
@@ -1063,13 +1143,18 @@ def test_main_with_example_data(tmpdir):
         assert 'geo_em.d04_NoUrban.nc' in contents
         assert 'geo_em.d04_LCZ_extent.nc' in contents
 
+
 def test_main_shanghai_data(tmpdir):
     input_dir = tmpdir.mkdir('input')
 
-    shutil.copy(os.path.join('testing', 'geo_em.d01_Shanghai_ncl20.nc'),
-                os.path.join(input_dir, 'geo_em.d01.nc'))
-    shutil.copy(os.path.join('testing', 'geo_em.d02_Shanghai.nc'),
-                os.path.join(input_dir, 'geo_em.d02.nc'))
+    shutil.copy(
+        os.path.join('testing', 'geo_em.d01_Shanghai_ncl20.nc'),
+        os.path.join(input_dir, 'geo_em.d01.nc'),
+    )
+    shutil.copy(
+        os.path.join('testing', 'geo_em.d02_Shanghai.nc'),
+        os.path.join(input_dir, 'geo_em.d02.nc'),
+    )
     shutil.copy(os.path.join('testing', 'Shanghai.tif'), input_dir)
 
     with tmpdir.as_cwd():
@@ -1080,6 +1165,7 @@ def test_main_shanghai_data(tmpdir):
         assert 'geo_em.d02_NoUrban.nc' in contents
         assert 'geo_em.d02_LCZ_extent.nc' in contents
 
+
 def test_main_default_lcz_ucp(tmpdir):
     input_dir = tmpdir.mkdir('input')
     input_files = (
@@ -1087,7 +1173,7 @@ def test_main_default_lcz_ucp(tmpdir):
         'geo_em.d03.nc',
         'geo_em.d03.nc',
         'geo_em.d04.nc',
-        'lcz_zaragoza.tif'
+        'lcz_zaragoza.tif',
     )
     for f in input_files:
         shutil.copy(os.path.join('sample_data', f), input_dir)
@@ -1099,6 +1185,7 @@ def test_main_default_lcz_ucp(tmpdir):
     exp_df = pd.read_csv('w2w/resources/LCZ_UCP_lookup.csv', index_col=0)
     pd.testing.assert_frame_equal(exp_df, m.call_args[1]['ucp_table'])
 
+
 def test_main_custom_lcz_ucp(tmpdir):
     input_dir = tmpdir.mkdir('input')
     input_files = (
@@ -1106,7 +1193,7 @@ def test_main_custom_lcz_ucp(tmpdir):
         'geo_em.d03.nc',
         'geo_em.d03.nc',
         'geo_em.d04.nc',
-        'lcz_zaragoza.tif'
+        'lcz_zaragoza.tif',
     )
     for f in input_files:
         shutil.copy(os.path.join('sample_data', f), input_dir)
@@ -1116,8 +1203,11 @@ def test_main_custom_lcz_ucp(tmpdir):
         with mock.patch.object(w2w.w2w, 'checks_and_cleaning') as m:
             main(
                 [
-                    'input', 'lcz_zaragoza.tif', 'geo_em.d04.nc',
-                    '--lcz-ucp', 'custom_lcz_ucp.csv',
+                    'input',
+                    'lcz_zaragoza.tif',
+                    'geo_em.d04.nc',
+                    '--lcz-ucp',
+                    'custom_lcz_ucp.csv',
                 ],
             )
 

--- a/w2w/w2w.py
+++ b/w2w/w2w.py
@@ -1,4 +1,5 @@
 import numpy as np
+
 np.seterr(divide='ignore', invalid='ignore')
 import pandas as pd
 import rioxarray as rxr
@@ -29,66 +30,84 @@ else:  # pragma: <3.9 cover
     import importlib_metadata
     import importlib_resources
 
+
 def main(argv: Optional[Sequence[str]] = None) -> int:
 
-    ''' Add WUDAPT info to WRF's '''
+    '''Add WUDAPT info to WRF's'''
 
     parser = argparse.ArgumentParser(
-        description="PURPOSE: Add LCZ-based info to WRF geo_em.d0X.nc\n \n"
-                    "OUTPUT:\n"
-                    "- *_NoUrban.nc: MODIS Urban replaced by surrounding natural LC\n"
-                    "- *_LCZ_extent.nc: LCZ urban extent implemented, no LCZ UCPs yet\n"
-                    "- *_LCZ_params.nc: LCZ urban extent + UPC parameter values\n"
-                    "- *_d0X_41.nc: Parent domain files reflecting 41 Land categories",
-        formatter_class=RawTextHelpFormatter
+        description='PURPOSE: Add LCZ-based info to WRF geo_em.d0X.nc\n \n'
+        'OUTPUT:\n'
+        '- *_NoUrban.nc: MODIS Urban replaced by surrounding natural LC\n'
+        '- *_LCZ_extent.nc: LCZ urban extent implemented, no LCZ UCPs yet\n'
+        '- *_LCZ_params.nc: LCZ urban extent + UPC parameter values\n'
+        '- *_d0X_41.nc: Parent domain files reflecting 41 Land categories',
+        formatter_class=RawTextHelpFormatter,
     )
 
     # Required arguments
-    parser.add_argument(type=str, dest='io_dir',
-                        help='Directory that contains geo_em.d0X.nc and LCZ.tif file',
-                        )
-    parser.add_argument(type=str, dest='lcz_file',
-                        help='LCZ map file name',
-                        )
-    parser.add_argument(type=str, dest='wrf_file',
-                        help='WRF geo_em* file name',
-                        )
+    parser.add_argument(
+        type=str,
+        dest='io_dir',
+        help='Directory that contains geo_em.d0X.nc and LCZ.tif file',
+    )
+    parser.add_argument(
+        type=str,
+        dest='lcz_file',
+        help='LCZ map file name',
+    )
+    parser.add_argument(
+        type=str,
+        dest='wrf_file',
+        help='WRF geo_em* file name',
+    )
 
     # Additional arguments
     parser.add_argument(
-        '-V', '--version',
+        '-V',
+        '--version',
         action='version',
         version=f'%(prog)s {importlib_metadata.version("w2w")}',
     )
-    parser.add_argument('-b', '--built-lcz',
-                        nargs='+',
-                        metavar='',
-                        type=int,
-                        dest='built_lcz',
-                        help='LCZ classes considered as urban '
-                             '(DEFAULT: 1 2 3 4 5 6 7 8 9 10)',
-                        default=[1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
-    parser.add_argument('-l', '--lcz-band',
-                        metavar='',
-                        type=int,
-                        dest='LCZ_BAND',
-                        help='Band to use from LCZ file (DEFAULT: 0). '
-                             'For maps produced with LCZ Generator, use 1',
-                        default=0)
-    parser.add_argument('-f', '--frc-threshold',
-                        metavar='',
-                        type=float,
-                        dest='FRC_THRESHOLD',
-                        help='FRC_URB2D treshold value to assign pixel as urban '
-                             '(DEFAULT: 0.2)',
-                        default=0.2)
-    parser.add_argument('-n', '--npix-nlc',
-                        metavar='',
-                        type=int,
-                        dest='NPIX_NLC',
-                        help='Number of pixels to use for sampling neighbouring '
-                             'natural land cover (DEFAULT: 45)',
-                        default=45)
+    parser.add_argument(
+        '-b',
+        '--built-lcz',
+        nargs='+',
+        metavar='',
+        type=int,
+        dest='built_lcz',
+        help='LCZ classes considered as urban ' '(DEFAULT: 1 2 3 4 5 6 7 8 9 10)',
+        default=[1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+    )
+    parser.add_argument(
+        '-l',
+        '--lcz-band',
+        metavar='',
+        type=int,
+        dest='LCZ_BAND',
+        help='Band to use from LCZ file (DEFAULT: 0). '
+        'For maps produced with LCZ Generator, use 1',
+        default=0,
+    )
+    parser.add_argument(
+        '-f',
+        '--frc-threshold',
+        metavar='',
+        type=float,
+        dest='FRC_THRESHOLD',
+        help='FRC_URB2D treshold value to assign pixel as urban ' '(DEFAULT: 0.2)',
+        default=0.2,
+    )
+    parser.add_argument(
+        '-n',
+        '--npix-nlc',
+        metavar='',
+        type=int,
+        dest='NPIX_NLC',
+        help='Number of pixels to use for sampling neighbouring '
+        'natural land cover (DEFAULT: 45)',
+        default=45,
+    )
     parser.add_argument(
         '--lcz-ucp',
         type=str,
@@ -105,29 +124,28 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         ).joinpath('LCZ_UCP_lookup.csv')
 
     # Execute the functions
-    print("--> Set files structure")
+    print('--> Set files structure')
     info = Info.from_argparse(args)
     ucp_table = pd.read_csv(lookup_table, index_col=0)
 
-    print("--> Check LCZ integrity, in terms of "
-          "class labels, projection and extent")
+    print('--> Check LCZ integrity, in terms of ' 'class labels, projection and extent')
     check_lcz_integrity(
         info=info,
         LCZ_BAND=args.LCZ_BAND,
     )
 
-    print("--> Replace WRF MODIS urban LC with surrounding natural LC")
+    print('--> Replace WRF MODIS urban LC with surrounding natural LC')
     wrf_remove_urban(
         info=info,
         NPIX_NLC=args.NPIX_NLC,
     )
 
-    print("--> Create temporary WRF grid .tif file for resampling")
+    print('--> Create temporary WRF grid .tif file for resampling')
     create_wrf_gridinfo(
         info=info,
     )
 
-    print("--> Create LCZ-based geo_em file")
+    print('--> Create LCZ-based geo_em file')
     nbui_max = create_lcz_params_file(
         info=info,
         FRC_THRESHOLD=args.FRC_THRESHOLD,
@@ -135,18 +153,20 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         ucp_table=ucp_table,
     )
 
-    print("--> Create LCZ-based urban extent geo_em file "
-          "(excluding other LCZ-based info)")
+    print(
+        '--> Create LCZ-based urban extent geo_em file '
+        '(excluding other LCZ-based info)'
+    )
     create_lcz_extent_file(
         info=info,
     )
 
-    print("--> Expanding land categories of parent domain(s) to 41")
+    print('--> Expanding land categories of parent domain(s) to 41')
     expand_land_cat_parents(
         info=info,
     )
 
-    print("\n--> Start sanity check and clean-up ...")
+    print('\n--> Start sanity check and clean-up ...')
     checks_and_cleaning(
         info=info,
         ucp_table=ucp_table,
@@ -159,6 +179,7 @@ class Info(NamedTuple):
     """
     Immutable class representing the configuration with all files and directories
     """
+
     io_dir: str
     src_file: str
     src_file_clean: str
@@ -174,23 +195,32 @@ class Info(NamedTuple):
         # Define output and tmp file(s), the latter is removed when done.
         return cls(
             io_dir=args.io_dir,
-            src_file = os.path.join(args.io_dir, args.lcz_file),
-            src_file_clean = os.path.join(args.io_dir, args.lcz_file.replace('.tif','_clean.tif')),
-            dst_file = os.path.join(args.io_dir, args.wrf_file),
-            dst_nu_file = os.path.join(args.io_dir, args.wrf_file.replace('.nc','_NoUrban.nc')),
+            src_file=os.path.join(args.io_dir, args.lcz_file),
+            src_file_clean=os.path.join(
+                args.io_dir, args.lcz_file.replace('.tif', '_clean.tif')
+            ),
+            dst_file=os.path.join(args.io_dir, args.wrf_file),
+            dst_nu_file=os.path.join(
+                args.io_dir, args.wrf_file.replace('.nc', '_NoUrban.nc')
+            ),
             # TMP file, will be removed
-            dst_gridinfo = os.path.join(args.io_dir, args.wrf_file.replace('.nc','_gridinfo.tif')),
-            dst_lcz_extent_file = os.path.join(args.io_dir, args.wrf_file.replace('.nc', '_LCZ_extent.nc')),
-            dst_lcz_params_file = os.path.join(args.io_dir, args.wrf_file.replace('.nc', '_LCZ_params.nc')),
+            dst_gridinfo=os.path.join(
+                args.io_dir, args.wrf_file.replace('.nc', '_gridinfo.tif')
+            ),
+            dst_lcz_extent_file=os.path.join(
+                args.io_dir, args.wrf_file.replace('.nc', '_LCZ_extent.nc')
+            ),
+            dst_lcz_params_file=os.path.join(
+                args.io_dir, args.wrf_file.replace('.nc', '_LCZ_params.nc')
+            ),
             BUILT_LCZ=args.built_lcz,
         )
 
 
-def _replace_lcz_number(lcz: xr.DataArray, lcz_to_change: NDArray[np.int_]) -> xr.DataArray:
-    lcz_expected = np.array(
-        [1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
-         11, 12, 13, 14, 15, 16, 17]
-    )
+def _replace_lcz_number(
+    lcz: xr.DataArray, lcz_to_change: NDArray[np.int_]
+) -> xr.DataArray:
+    lcz_expected = np.array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17])
 
     lcz_arr = lcz.data.flatten().astype(np.int32)
     df = pd.Series(lcz_arr, dtype=lcz_expected.dtype)
@@ -198,11 +228,10 @@ def _replace_lcz_number(lcz: xr.DataArray, lcz_to_change: NDArray[np.int_]) -> x
     d = dict(zip(lcz_to_change, lcz_expected))
 
     lcz_new = lcz.copy()
-    lcz_new.data = df.map(d).values\
-        .reshape(lcz.shape)\
-        .astype(np.int32)
+    lcz_new.data = df.map(d).values.reshape(lcz.shape).astype(np.int32)
 
     return lcz_new
+
 
 def _check_lcz_wrf_extent(lcz: xr.DataArray, wrf: xr.Dataset) -> None:
 
@@ -211,24 +240,33 @@ def _check_lcz_wrf_extent(lcz: xr.DataArray, wrf: xr.Dataset) -> None:
 
     # Get bounding box coordinates
     lcz_xmin, lcz_ymin, lcz_xmax, lcz_ymax = lcz.rio.bounds()
-    wrf_xmin, wrf_ymin, wrf_xmax, wrf_ymax = \
-        float(wrf.XLONG_M.min()), float(wrf.XLAT_M.min()), \
-        float(wrf.XLONG_M.max()), float(wrf.XLAT_M.max())
+    wrf_xmin, wrf_ymin, wrf_xmax, wrf_ymax = (
+        float(wrf.XLONG_M.min()),
+        float(wrf.XLAT_M.min()),
+        float(wrf.XLONG_M.max()),
+        float(wrf.XLAT_M.max()),
+    )
 
     # Evaluate and throw error if WRF not within LCZ domain
-    if not (wrf_xmin > lcz_xmin ) & (wrf_xmax < lcz_xmax ) & \
-           (wrf_ymin > lcz_ymin) & (wrf_ymax < lcz_ymax):
+    if (
+        not (wrf_xmin > lcz_xmin)
+        & (wrf_xmax < lcz_xmax)
+        & (wrf_ymin > lcz_ymin)
+        & (wrf_ymax < lcz_ymax)
+    ):
 
-        message = f"{ERROR}ERROR: LCZ domain should be larger than " \
-                  "WRF domain in all directions.\n" \
-                  "LCZ bounds (xmin, ymin, xmax, ymax): " \
-                 f"{lcz_xmin, lcz_ymin, lcz_xmax, lcz_ymax}\n" \
-                  "WRF bounds (xmin, ymin, xmax, ymax): "\
-                 f"{wrf_xmin, wrf_ymin, wrf_xmax, wrf_ymax}{ENDC}"
+        message = (
+            f'{ERROR}ERROR: LCZ domain should be larger than '
+            'WRF domain in all directions.\n'
+            'LCZ bounds (xmin, ymin, xmax, ymax): '
+            f'{lcz_xmin, lcz_ymin, lcz_xmax, lcz_ymax}\n'
+            'WRF bounds (xmin, ymin, xmax, ymax): '
+            f'{wrf_xmin, wrf_ymin, wrf_xmax, wrf_ymax}{ENDC}'
+        )
         print(message)
         sys.exit(1)
     else:
-        print("> LCZ domain is covering WRF domain")
+        print('> LCZ domain is covering WRF domain')
 
 
 def check_lcz_integrity(info: Info, LCZ_BAND: int) -> None:
@@ -252,26 +290,25 @@ def check_lcz_integrity(info: Info, LCZ_BAND: int) -> None:
 
     # If any of [101, 102, 103, 104, 105, 106, 107] is in the lcz tif file.
     lcz_100 = np.array(
-        [1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
-         101, 102, 103, 104, 105, 106, 107]
+        [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 101, 102, 103, 104, 105, 106, 107]
     )
     if any(x in lcz.data.flatten() for x in lcz_100[10:]):
         lcz = _replace_lcz_number(
             lcz=lcz,
             lcz_to_change=lcz_100,
         )
-        print("> LCZ class labels renamed from 1 to 17")
+        print('> LCZ class labels renamed from 1 to 17')
     else:
-        print("> LCZ labels as expected (1 to 17)")
+        print('> LCZ labels as expected (1 to 17)')
 
     # Re-project when not WGS84 (EPSG:4326)
     if lcz.rio.crs != CRS.from_epsg(4326):
-        lcz = lcz.rio.reproject("EPSG:4326")
+        lcz = lcz.rio.reproject('EPSG:4326')
         lcz.data = xr.where(lcz.data > 0, lcz.data, 0)
         lcz.data = lcz.data.astype(np.int32)
-        print("> LCZ map reprojected to WGS84 (EPSG:4326)")
+        print('> LCZ map reprojected to WGS84 (EPSG:4326)')
     else:
-        print("> LCZ provided as WGS84 (EPSG:4326)")
+        print('> LCZ provided as WGS84 (EPSG:4326)')
 
     # Check if LCZ map exceeds domain of geo_em file in all directions
     _check_lcz_wrf_extent(lcz, wrf)
@@ -280,27 +317,34 @@ def check_lcz_integrity(info: Info, LCZ_BAND: int) -> None:
     lcz.rio.to_raster(info.src_file_clean, dtype=np.int32)
 
 
-def _calc_distance_coord(lat1: float, lon1: float, lat2: float, lon2: float) -> xr.DataArray:
+def _calc_distance_coord(
+    lat1: float, lon1: float, lat2: float, lon2: float
+) -> xr.DataArray:
 
     '''Calculate distance using coordinates
-       This uses the spherical law of cosines
+    This uses the spherical law of cosines
     '''
 
-    earth_radius=6371000 #Earth radius in m
-    lat1r = lat1*np.pi/180.
-    lat2r = lat2*np.pi/180.
-    lon1r = lon1*np.pi/180.
-    lon2r = lon2*np.pi/180.
+    earth_radius = 6371000  # Earth radius in m
+    lat1r = lat1 * np.pi / 180.0
+    lat2r = lat2 * np.pi / 180.0
+    lon1r = lon1 * np.pi / 180.0
+    lon2r = lon2 * np.pi / 180.0
 
-    d = np.arccos(np.sin(lat1r)*np.sin(lat2r) +
-                  np.cos(lat1r)*np.cos(lat2r)*
-                  np.cos(lon2r-lon1r))*earth_radius
+    d = (
+        np.arccos(
+            np.sin(lat1r) * np.sin(lat2r)
+            + np.cos(lat1r) * np.cos(lat2r) * np.cos(lon2r - lon1r)
+        )
+        * earth_radius
+    )
 
     return d
 
+
 def wrf_remove_urban(
-        info: Info,
-        NPIX_NLC: int,
+    info: Info,
+    NPIX_NLC: int,
 ) -> None:
 
     '''Remove MODIS urban extent from geo_em*.nc file'''
@@ -314,81 +358,93 @@ def wrf_remove_urban(
     greenf = dst_data.GREENFRAC.squeeze()
     lat = dst_data.XLAT_M.squeeze()
     lon = dst_data.XLONG_M.squeeze()
-    newluse=luse.values.copy()
-    newluf=luf.values.copy()
-    newgreenf=greenf.values.copy()
-    orig_num_land_cat=dst_data.NUM_LAND_CAT
+    newluse = luse.values.copy()
+    newluf = luf.values.copy()
+    newgreenf = greenf.values.copy()
+    orig_num_land_cat = dst_data.NUM_LAND_CAT
 
     # Convert urban to surrounding natural characteristics
     for i in dst_data.south_north:
         for j in dst_data.west_east:
-            if luse.isel(south_north=i,west_east=j) == 13:
+            if luse.isel(south_north=i, west_east=j) == 13:
 
                 dis = _calc_distance_coord(
-                         lat.where((luse!=13) & (luse!=17) & (luse!=21)),
-                         lon.where((luse!=13) & (luse!=17) & (luse!=21)),
-                         lat.isel(south_north=i,west_east=j),
-                         lon.isel(south_north=i,west_east=j)
-                         )
+                    lat.where((luse != 13) & (luse != 17) & (luse != 21)),
+                    lon.where((luse != 13) & (luse != 17) & (luse != 21)),
+                    lat.isel(south_north=i, west_east=j),
+                    lon.isel(south_north=i, west_east=j),
+                )
 
-                disflat = dis.stack(gridpoints=('south_north','west_east'))\
-                    .reset_index('gridpoints').drop_vars(['south_north','west_east'])
-                aux = luse.where(dis<=disflat.sortby(disflat)
-                                 .isel(gridpoints=NPIX_NLC),drop=True)
-                m = stats.mode(aux.values.flatten(), nan_policy="omit")[0]
+                disflat = (
+                    dis.stack(gridpoints=('south_north', 'west_east'))
+                    .reset_index('gridpoints')
+                    .drop_vars(['south_north', 'west_east'])
+                )
+                aux = luse.where(
+                    dis <= disflat.sortby(disflat).isel(gridpoints=NPIX_NLC), drop=True
+                )
+                m = stats.mode(aux.values.flatten(), nan_policy='omit')[0]
                 newluse[i, j] = int(m)
 
-                auxg = greenf.where(dis<=disflat.sortby(disflat)
-                                    .isel(gridpoints=NPIX_NLC),drop=True)\
-                    .where(aux==newluse[i,j]).mean(dim=['south_north','west_east'])
-                newgreenf[:,i,j]=auxg
+                auxg = (
+                    greenf.where(
+                        dis <= disflat.sortby(disflat).isel(gridpoints=NPIX_NLC),
+                        drop=True,
+                    )
+                    .where(aux == newluse[i, j])
+                    .mean(dim=['south_north', 'west_east'])
+                )
+                newgreenf[:, i, j] = auxg
 
-            if luf.isel(south_north=i,west_east=j,land_cat=12)>0.:
-                if orig_num_land_cat>20: #USING MODIS_LAKE
+            if luf.isel(south_north=i, west_east=j, land_cat=12) > 0.0:
+                if orig_num_land_cat > 20:  # USING MODIS_LAKE
                     dis = _calc_distance_coord(
-                             lat.where(
-                                        (luf.isel(land_cat=12)==0.) &
-                                        (luf.isel(land_cat=16)==0.) &
-                                        (luf.isel(land_cat=20)==0.)
-                                      ),
-
-                             lon.where(
-                                        (luf.isel(land_cat=12)==0.) &
-                                        (luf.isel(land_cat=16)==0.) &
-                                        (luf.isel(land_cat=20)==0.)
-                                      ),
-                             lat.isel(south_north=i,west_east=j),
-                             lon.isel(south_north=i,west_east=j)
-                             )
-                else: #USING MODIS (NO LAKES)
+                        lat.where(
+                            (luf.isel(land_cat=12) == 0.0)
+                            & (luf.isel(land_cat=16) == 0.0)
+                            & (luf.isel(land_cat=20) == 0.0)
+                        ),
+                        lon.where(
+                            (luf.isel(land_cat=12) == 0.0)
+                            & (luf.isel(land_cat=16) == 0.0)
+                            & (luf.isel(land_cat=20) == 0.0)
+                        ),
+                        lat.isel(south_north=i, west_east=j),
+                        lon.isel(south_north=i, west_east=j),
+                    )
+                else:  # USING MODIS (NO LAKES)
                     dis = _calc_distance_coord(
-                             lat.where(
-                                        (luf.isel(land_cat=12)==0.) &
-                                        (luf.isel(land_cat=16)==0.)
-                                      ),
+                        lat.where(
+                            (luf.isel(land_cat=12) == 0.0)
+                            & (luf.isel(land_cat=16) == 0.0)
+                        ),
+                        lon.where(
+                            (luf.isel(land_cat=12) == 0.0)
+                            & (luf.isel(land_cat=16) == 0.0)
+                        ),
+                        lat.isel(south_north=i, west_east=j),
+                        lon.isel(south_north=i, west_east=j),
+                    )
 
-                             lon.where(
-                                        (luf.isel(land_cat=12)==0.) &
-                                        (luf.isel(land_cat=16)==0.)
-                                      ),
-                             lat.isel(south_north=i,west_east=j),
-                             lon.isel(south_north=i,west_east=j)
-                             )
-
-                disflat = dis.stack(gridpoints=('south_north','west_east'))\
-                    .reset_index('gridpoints').drop_vars(['south_north','west_east'])
-                aux = luse.where(dis<=disflat.sortby(disflat)
-                                 .isel(gridpoints=NPIX_NLC),drop=True)
-                m = stats.mode(aux.values.flatten(), nan_policy="omit")[0]
+                disflat = (
+                    dis.stack(gridpoints=('south_north', 'west_east'))
+                    .reset_index('gridpoints')
+                    .drop_vars(['south_north', 'west_east'])
+                )
+                aux = luse.where(
+                    dis <= disflat.sortby(disflat).isel(gridpoints=NPIX_NLC), drop=True
+                )
+                m = stats.mode(aux.values.flatten(), nan_policy='omit')[0]
                 newlu = int(m) - 1
-                #newlu = int(mode(aux.values.flatten())[0])-1
-                newluf[newlu,i,j]+=luf.isel(south_north=i,west_east=j,land_cat=12).values
-                newluf[12,i,j]=0.
+                # newlu = int(mode(aux.values.flatten())[0])-1
+                newluf[newlu, i, j] += luf.isel(
+                    south_north=i, west_east=j, land_cat=12
+                ).values
+                newluf[12, i, j] = 0.0
 
-
-    dst_data.LU_INDEX.values[0,:]=newluse[:]
-    dst_data.LANDUSEF.values[0,:]=newluf[:]
-    dst_data.GREENFRAC.values[0,:]=newgreenf[:]
+    dst_data.LU_INDEX.values[0, :] = newluse[:]
+    dst_data.LANDUSEF.values[0, :] = newluf[:]
+    dst_data.GREENFRAC.values[0, :] = newgreenf[:]
 
     # Save to final _lcz_params file
     if os.path.exists(info.dst_nu_file):
@@ -404,14 +460,17 @@ def create_wrf_gridinfo(info: Info) -> None:
 
     # Create simpler WRF grid target.
     da_lu = xr.Dataset(
-        {'LU_INDEX': (['y', 'x'],  dst_data['LU_INDEX'][0, :, :].values)},
-        coords={'y': dst_data.XLAT_M.values[0, :, 0],
-                'x': dst_data.XLONG_M.values[0, 0, :]}
+        {'LU_INDEX': (['y', 'x'], dst_data['LU_INDEX'][0, :, :].values)},
+        coords={
+            'y': dst_data.XLAT_M.values[0, :, 0],
+            'x': dst_data.XLONG_M.values[0, 0, :],
+        },
     )
 
     # Add projection information as attributes, save and read back in.
-    da_lu.rio.write_crs("epsg:4326", inplace=True)
+    da_lu.rio.write_crs('epsg:4326', inplace=True)
     da_lu.rio.to_raster(info.dst_gridinfo)
+
 
 def _get_SW_BW(ucp_table: pd.DataFrame) -> Tuple[pd.Series, pd.Series]:
 
@@ -420,20 +479,22 @@ def _get_SW_BW(ucp_table: pd.DataFrame) -> Tuple[pd.Series, pd.Series]:
     # Street width extracted from S02012 Building heighht and H2W.
     SW = ucp_table['MH_URB2D'] / ucp_table['H2W']
     # Building Width according to bldfr_urb2d/(frc_urb2d-bldfr_urb2d)*sw
-    BW = (ucp_table['BLDFR_URB2D'] /
-          (ucp_table['FRC_URB2D'] - ucp_table['BLDFR_URB2D'])) \
-         * SW
+    BW = (
+        ucp_table['BLDFR_URB2D'] / (ucp_table['FRC_URB2D'] - ucp_table['BLDFR_URB2D'])
+    ) * SW
 
     return SW, BW
 
-def _get_lcz_arr(src_data: xr.DataArray, info: Info)-> NDArray[np.int_]:
 
-    ''' Get LCZ data as array, setting non-built pixels to 0'''
+def _get_lcz_arr(src_data: xr.DataArray, info: Info) -> NDArray[np.int_]:
+
+    '''Get LCZ data as array, setting non-built pixels to 0'''
 
     # Get mask of selected built LCZs
     lcz_urb_mask = xr.DataArray(
         np.in1d(src_data, info.BUILT_LCZ).reshape(src_data.shape),
-        dims=src_data.dims, coords=src_data.coords
+        dims=src_data.dims,
+        coords=src_data.coords,
     )
 
     # Get LCZ class values only.
@@ -444,13 +505,14 @@ def _get_lcz_arr(src_data: xr.DataArray, info: Info)-> NDArray[np.int_]:
 
     return lcz_arr
 
+
 def _ucp_resampler(
-        info: Info,
-        ucp_key: str,
-        RESAMPLE_TYPE: str,
-        ucp_table: pd.DataFrame,
-        **kwargs: float,
-)-> xr.DataArray:
+    info: Info,
+    ucp_key: str,
+    RESAMPLE_TYPE: str,
+    ucp_table: pd.DataFrame,
+    **kwargs: float,
+) -> xr.DataArray:
 
     '''Helper function to resample lcz ucp data ('FRC_URB2D', 'MH_URB2D',
     'STDH_URB2D', 'LB_URB2D', 'LF_URB2D', 'LP_URB2D') to WRF grid'''
@@ -478,8 +540,9 @@ def _ucp_resampler(
             lookup = LAMBDA_F.loc[info.BUILT_LCZ]
 
     elif ucp_key == 'STDH_URB2D':
-        lookup = ((ucp_table['MH_URB2D_MAX']-
-                  ucp_table['MH_URB2D_MIN'])/4).loc[info.BUILT_LCZ]
+        lookup = ((ucp_table['MH_URB2D_MAX'] - ucp_table['MH_URB2D_MIN']) / 4).loc[
+            info.BUILT_LCZ
+        ]
     else:
         lookup = ucp_table[ucp_key].loc[info.BUILT_LCZ]
 
@@ -495,7 +558,7 @@ def _ucp_resampler(
     lcz_data_da = xr.Dataset(
         {'band': (['y', 'x'], lcz_data)},
         coords={'y': src_data.y.values, 'x': src_data.x.values},
-        attrs={'transform': src_data.rio.transform(), 'crs': src_data.rio.crs}
+        attrs={'transform': src_data.rio.transform(), 'crs': src_data.rio.crs},
     ).to_array()
 
     # Info: https://rasterio.readthedocs.io/en/latest/api/rasterio.warp.html?highlight=reproject(#rasterio.warp.reproject
@@ -506,14 +569,12 @@ def _ucp_resampler(
         src_crs=lcz_data_da.rio.crs,
         dst_transform=dst_grid.rio.transform(),
         dst_crs=dst_grid.rio.crs,
-        resampling=Resampling[RESAMPLE_TYPE])[0]
+        resampling=Resampling[RESAMPLE_TYPE],
+    )[0]
 
     # In case of FRC_URB2D, filter for too low values
     if 'FRC_THRESHOLD' in kwargs.keys():
-        ucp_2_wrf = ucp_2_wrf.where(
-            ucp_2_wrf > kwargs['FRC_THRESHOLD'],
-            0
-        )
+        ucp_2_wrf = ucp_2_wrf.where(ucp_2_wrf > kwargs['FRC_THRESHOLD'], 0)
 
     ## In case nans occur, set to zero
     ucp_2_wrf.values[0, np.isnan(ucp_2_wrf[0, :, :])] = 0
@@ -522,10 +583,10 @@ def _ucp_resampler(
 
 
 def _hgt_resampler(
-        info: Info,
-        RESAMPLE_TYPE: str,
-        ucp_table: pd.DataFrame,
-)-> xr.DataArray:
+    info: Info,
+    RESAMPLE_TYPE: str,
+    ucp_table: pd.DataFrame,
+) -> xr.DataArray:
 
     '''Helper function to resample HGT_URB2D (=Area Weighted
     Mean Building Height ) data to WRF grid'''
@@ -538,8 +599,7 @@ def _hgt_resampler(
     SW, BW = _get_SW_BW(ucp_table)
 
     # Get Look-up for HGT values
-    lookup_nom = BW.loc[info.BUILT_LCZ] ** 2 \
-                 * ucp_table['MH_URB2D'].loc[info.BUILT_LCZ]
+    lookup_nom = BW.loc[info.BUILT_LCZ] ** 2 * ucp_table['MH_URB2D'].loc[info.BUILT_LCZ]
     lookup_denom = BW.loc[info.BUILT_LCZ] ** 2
 
     # Get mask of selected built LCZs
@@ -559,12 +619,12 @@ def _hgt_resampler(
     lcz_data_da_nom = xr.Dataset(
         {'band': (['y', 'x'], dataLcz_nom)},
         coords={'y': src_data.y.values, 'x': src_data.x.values},
-        attrs={'transform': src_data.rio.transform(), 'crs': src_data.rio.crs}
+        attrs={'transform': src_data.rio.transform(), 'crs': src_data.rio.crs},
     ).to_array()
     lcz_data_da_denom = xr.Dataset(
         {'band': (['y', 'x'], dataLcz_denom)},
         coords={'y': src_data.y.values, 'x': src_data.x.values},
-        attrs={'transform': src_data.rio.transform(), 'crs': src_data.rio.crs}
+        attrs={'transform': src_data.rio.transform(), 'crs': src_data.rio.crs},
     ).to_array()
 
     # Get the aggregated values on WRF grid - nominator
@@ -575,7 +635,8 @@ def _hgt_resampler(
         src_crs=lcz_data_da_nom.crs,
         dst_transform=dst_grid.rio.transform(),
         dst_crs=dst_grid.rio.crs,
-        resampling=Resampling[RESAMPLE_TYPE])[0].copy()
+        resampling=Resampling[RESAMPLE_TYPE],
+    )[0].copy()
 
     # Get the aggregated values on WRF grid - nominator
     ucp_2_wrf_denom = reproject(
@@ -585,38 +646,45 @@ def _hgt_resampler(
         src_crs=lcz_data_da_denom.crs,
         dst_transform=dst_grid.rio.transform(),
         dst_crs=dst_grid.rio.crs,
-        resampling=Resampling[RESAMPLE_TYPE])[0].copy()
+        resampling=Resampling[RESAMPLE_TYPE],
+    )[0].copy()
 
     hgt_urb2d = ucp_2_wrf_nom / ucp_2_wrf_denom
 
     ## In case nans occur, set to zero
-    hgt_urb2d.values[0,np.isnan(hgt_urb2d[0,:,:])] = 0
+    hgt_urb2d.values[0, np.isnan(hgt_urb2d[0, :, :])] = 0
 
     return hgt_urb2d
 
-def _get_truncated_normal_sample(lcz_i: int,
-                                 ucp_table: pd.DataFrame,
-                                 SAMPLE_SIZE: int = 100000) -> NDArray[np.float_]:
 
-    ''' Helper function to return bounded normal distribution sample'''
+def _get_truncated_normal_sample(
+    lcz_i: int, ucp_table: pd.DataFrame, SAMPLE_SIZE: int = 100000
+) -> NDArray[np.float_]:
+
+    '''Helper function to return bounded normal distribution sample'''
 
     # Create instance of a truncated normal distribution
     low = ucp_table['MH_URB2D_MIN'].loc[lcz_i]
     mean = ucp_table['MH_URB2D'].loc[lcz_i]
     upp = ucp_table['MH_URB2D_MAX'].loc[lcz_i]
-    sd = (ucp_table['MH_URB2D_MAX'].loc[lcz_i] -
-            ucp_table['MH_URB2D_MIN'].loc[lcz_i]) / 4
+    sd = (
+        ucp_table['MH_URB2D_MAX'].loc[lcz_i] - ucp_table['MH_URB2D_MIN'].loc[lcz_i]
+    ) / 4
 
-    hi_inst = truncnorm(
-        (low - mean) / sd, (upp - mean) / sd, loc=mean, scale=sd
-    )
+    hi_inst = truncnorm((low - mean) / sd, (upp - mean) / sd, loc=mean, scale=sd)
 
     # populate with large enough sample for accuracy
     hi_sample = hi_inst.rvs(SAMPLE_SIZE)
 
     return hi_sample
 
-def _check_hi_values(lcz_i: int, hi_sample: NDArray[np.float_], ucp_table: pd.DataFrame, ERROR_MARGIN: float) -> None:
+
+def _check_hi_values(
+    lcz_i: int,
+    hi_sample: NDArray[np.float_],
+    ucp_table: pd.DataFrame,
+    ERROR_MARGIN: float,
+) -> None:
     hi_metrics = [
         'MH_URB2D_MIN',
         'MH_URB2D_MAX',
@@ -633,32 +701,50 @@ def _check_hi_values(lcz_i: int, hi_sample: NDArray[np.float_], ucp_table: pd.Da
         elif hi_metric == 'MH_URB2D':
             hi_sample_values = hi_sample.mean()
 
-        if not ucp_table[hi_metric].loc[lcz_i] * (1 - ERROR_MARGIN) < \
-               hi_sample_values < \
-               ucp_table[hi_metric].loc[lcz_i] * (1 + ERROR_MARGIN):
-            print(f"WARNING: {hi_metric} distribution not in "
-                  f"expected range ({ERROR_MARGIN*100}% marging) for LCZ class {lcz_i}: "
-                  f"modelled: {np.round(hi_sample_values, 2)} | "
-                  f"expected: ["
-                  f"{np.round(ucp_table[hi_metric].loc[lcz_i] * (1 - ERROR_MARGIN),2)} - "
-                  f"{np.round(ucp_table[hi_metric].loc[lcz_i] * (1 - ERROR_MARGIN),2)}]")
+        if (
+            not ucp_table[hi_metric].loc[lcz_i] * (1 - ERROR_MARGIN)
+            < hi_sample_values
+            < ucp_table[hi_metric].loc[lcz_i] * (1 + ERROR_MARGIN)
+        ):
+            print(
+                f'WARNING: {hi_metric} distribution not in '
+                f'expected range ({ERROR_MARGIN*100}% marging) for LCZ class {lcz_i}: '
+                f'modelled: {np.round(hi_sample_values, 2)} | '
+                f'expected: ['
+                f'{np.round(ucp_table[hi_metric].loc[lcz_i] * (1 - ERROR_MARGIN),2)} - '
+                f'{np.round(ucp_table[hi_metric].loc[lcz_i] * (1 - ERROR_MARGIN),2)}]'
+            )
+
 
 def _compute_hi_distribution(
-        info: Info,
-        ucp_table: pd.DataFrame,
-        SAMPLE_SIZE: int = 100000,
-        ERROR_MARGIN: float = 0.05,
+    info: Info,
+    ucp_table: pd.DataFrame,
+    SAMPLE_SIZE: int = 100000,
+    ERROR_MARGIN: float = 0.05,
 ) -> pd.DataFrame:
 
-    ''' Helper function to compute building height distribution'''
+    '''Helper function to compute building height distribution'''
 
     # Initialize dataframe that stores building height distributions
     df_hi = pd.DataFrame(
-        index = range(1,18,1),
-        columns = ['0 - <5m', '5 - <10m', '10 - <15m', '15 - <20m',
-                   '20 - <25m', '25 - <30m', '30 - <35m', '35 - <40m',
-                   '40 - <45m', '45 - <50m', '50 - <55m', '55 - <60m',
-                   '60 - <65m', '65 - <70m', '70 - <75m']
+        index=range(1, 18, 1),
+        columns=[
+            '0 - <5m',
+            '5 - <10m',
+            '10 - <15m',
+            '15 - <20m',
+            '20 - <25m',
+            '25 - <30m',
+            '30 - <35m',
+            '35 - <40m',
+            '40 - <45m',
+            '45 - <50m',
+            '50 - <55m',
+            '55 - <60m',
+            '60 - <65m',
+            '65 - <70m',
+            '70 - <75m',
+        ],
     )
 
     for i in info.BUILT_LCZ:
@@ -682,29 +768,31 @@ def _compute_hi_distribution(
             )
 
             # Count the values within pre-set bins
-            count_bins = np.histogram(hi_sample, bins=np.arange(0,76,5))[0]
-            count_bins = count_bins/(SAMPLE_SIZE/100) # Convert to %
+            count_bins = np.histogram(hi_sample, bins=np.arange(0, 76, 5))[0]
+            count_bins = count_bins / (SAMPLE_SIZE / 100)  # Convert to %
 
             # Add to dataframe
-            df_hi.loc[i,:] = count_bins
+            df_hi.loc[i, :] = count_bins
 
         # Set nans to zero
         df_hi = df_hi.fillna(0)
 
     return df_hi
 
+
 def _scale_hi(array: NDArray[np.int_]) -> List[float]:
 
-    ''' Helper function to scale HI_URB2D to 100%'''
+    '''Helper function to scale HI_URB2D to 100%'''
 
     scaled_array = [(float(i) / sum(array) * 100.0) for i in array]
     return scaled_array
 
+
 def _hi_resampler(
-        info: Info,
-        RESAMPLE_TYPE: str,
-        ucp_table: pd.DataFrame,
-        HI_THRES_MIN: int = 5,
+    info: Info,
+    RESAMPLE_TYPE: str,
+    ucp_table: pd.DataFrame,
+    HI_THRES_MIN: int = 5,
 ) -> Tuple[NDArray[np.float_], float]:
 
     '''Helper function to resample ucp HI_URB2D_URB2D data to WRF grid'''
@@ -720,12 +808,12 @@ def _hi_resampler(
     df_hi = _compute_hi_distribution(info, ucp_table=ucp_table)
 
     # Initialize array to store temp values
-    hi_arr = np.zeros((15,dst_grid.shape[1],dst_grid.shape[2]))
+    hi_arr = np.zeros((15, dst_grid.shape[1], dst_grid.shape[2]))
 
     # Loop over the 15 height density classes.
     for hi_i in range(df_hi.shape[1]):
 
-        #print(f"Working on height interval {df_hi.columns[hi_i]} ...")
+        # print(f"Working on height interval {df_hi.columns[hi_i]} ...")
         lookup = df_hi.iloc[:, hi_i].loc[info.BUILT_LCZ]
 
         # Make replacer object to map UCP values on LCZ class values
@@ -737,7 +825,7 @@ def _hi_resampler(
         lcz_data_da = xr.Dataset(
             {'band': (['y', 'x'], lcz_data)},
             coords={'y': src_data.y.values, 'x': src_data.x.values},
-            attrs={'transform': src_data.rio.transform(), 'crs': src_data.rio.crs}
+            attrs={'transform': src_data.rio.transform(), 'crs': src_data.rio.crs},
         ).to_array()
 
         # Get the aggregated values on WRF grid
@@ -748,7 +836,8 @@ def _hi_resampler(
             src_crs=lcz_data_da.rio.crs,
             dst_transform=dst_grid.rio.transform(),
             dst_crs=dst_grid.rio.crs,
-            resampling=Resampling[RESAMPLE_TYPE])[0]
+            resampling=Resampling[RESAMPLE_TYPE],
+        )[0]
 
         ## In case nans occur, set to zero
         ucp_2_wrf.values[0, np.isnan(ucp_2_wrf[0, :, :])] = 0
@@ -771,9 +860,9 @@ def _hi_resampler(
 
 
 def _lcz_resampler(
-        info: Info,
-        frc_urb2d: xr.DataArray,
-        LCZ_NAT_MASK: bool,
+    info: Info,
+    frc_urb2d: xr.DataArray,
+    LCZ_NAT_MASK: bool,
 ) -> Tuple[NDArray[np.bool_], NDArray[np.float_]]:
 
     '''Helper function to resample lcz classes to WRF grid using majority'''
@@ -785,9 +874,7 @@ def _lcz_resampler(
 
     # Mask natural LCZs before majority filtering.
     if LCZ_NAT_MASK:
-        src_data = src_data.where(
-            src_data.isin(info.BUILT_LCZ)
-        ).copy()
+        src_data = src_data.where(src_data.isin(info.BUILT_LCZ)).copy()
 
     lcz_2_wrf = reproject(
         src_data,
@@ -796,48 +883,48 @@ def _lcz_resampler(
         src_crs=src_data.rio.crs,
         dst_transform=dst_grid.rio.transform(),
         dst_crs=dst_grid.rio.crs,
-        resampling=Resampling['mode'])[0].values
+        resampling=Resampling['mode'],
+    )[0].values
 
     # if LCZ 15 selected in 'BUILT_LCZ', rename to 11
     if 15 in info.BUILT_LCZ:
         lcz_2_wrf[lcz_2_wrf == 15] = 11
 
     # Only keep LCZ pixels where FRC_URB2D > 0, for concistency
-    frc_mask = frc_urb2d.values[0,:,:] != 0
+    frc_mask = frc_urb2d.values[0, :, :] != 0
 
     # Final LU_INDEX = 31 to 41 (included), as LCZ classes.
-    lcz_resampled = lcz_2_wrf[0,frc_mask] + 30
+    lcz_resampled = lcz_2_wrf[0, frc_mask] + 30
 
     return frc_mask, lcz_resampled
 
 
 def _adjust_greenfrac_landusef(
-        info: Info,
-        dst_data: xr.Dataset,
-        frc_mask: NDArray[np.bool_],
+    info: Info,
+    dst_data: xr.Dataset,
+    frc_mask: NDArray[np.bool_],
 ) -> xr.Dataset:
 
     dst_data_orig = xr.open_dataset(info.dst_file)
-    orig_num_land_cat=dst_data_orig.NUM_LAND_CAT
+    orig_num_land_cat = dst_data_orig.NUM_LAND_CAT
 
     # Adjust GREENFRAC and LANDUSEF
     # GREENFRAC is set as average / month from GREENFRAC
     # of original MODIS urban pixels
     wrf_urb = xr.DataArray(
-        np.in1d(dst_data_orig['LU_INDEX'][0, :, :].values, [13])\
-            .reshape(dst_data_orig['LU_INDEX'][0, :, :].shape),
+        np.in1d(dst_data_orig['LU_INDEX'][0, :, :].values, [13]).reshape(
+            dst_data_orig['LU_INDEX'][0, :, :].shape
+        ),
         dims=dst_data_orig['LU_INDEX'][0, :, :].dims,
-        coords=dst_data_orig['LU_INDEX'][0, :, :].coords
+        coords=dst_data_orig['LU_INDEX'][0, :, :].coords,
     )
     greenfrac_per_month = [
-        dst_data_orig['GREENFRAC'].values[0, mm, wrf_urb].mean()
-        for mm in range(12)
+        dst_data_orig['GREENFRAC'].values[0, mm, wrf_urb].mean() for mm in range(12)
     ]
 
     # Loop over months and set average values
     for mm in range(12):
-        dst_data['GREENFRAC'].values[0, mm, frc_mask] = \
-            greenfrac_per_month[mm]
+        dst_data['GREENFRAC'].values[0, mm, frc_mask] = greenfrac_per_month[mm]
 
     # TODO: For lower resolution domains, this might not be valid?
     # Create new LANDUSEF with 41 levels instead of 21
@@ -846,17 +933,18 @@ def _adjust_greenfrac_landusef(
     )
 
     # Copy values from original file
-    landusef_new[:orig_num_land_cat,:,:] = \
-        dst_data['LANDUSEF'][0, :orig_num_land_cat, :, :]
+    landusef_new[:orig_num_land_cat, :, :] = dst_data['LANDUSEF'][
+        0, :orig_num_land_cat, :, :
+    ]
 
     # First set all values to zero for urban mask
-    landusef_new[:, frc_mask] = 0 # First all to 0, so sum remains 1 in the end
+    landusef_new[:, frc_mask] = 0  # First all to 0, so sum remains 1 in the end
 
     # LOOP over LCZ LU_INDEX values, and set to 1 there
     # So e.g. LANDUSE[0,31-1,:,1] = 1, where LU_INDEX = 31 (=LCZ 1)
-    for lu_i in np.arange(31,42,1):
+    for lu_i in np.arange(31, 42, 1):
         lu_mask = dst_data.LU_INDEX == int(lu_i)
-        landusef_new[int(lu_i)-1, lu_mask[0, :, :]] = 1
+        landusef_new[int(lu_i) - 1, lu_mask[0, :, :]] = 1
         del lu_mask
 
     # First store orginal attributes, then drop variable
@@ -867,9 +955,9 @@ def _adjust_greenfrac_landusef(
     landusef_new = np.expand_dims(landusef_new, axis=0)
 
     # Add back to data-array, including (altered) attributes
-    dst_data['LANDUSEF'] =     (
+    dst_data['LANDUSEF'] = (
         ('Time', 'land_cat', 'south_north', 'west_east'),
-        landusef_new
+        landusef_new,
     )
     dst_data['LANDUSEF'] = dst_data.LANDUSEF.astype('float32')
 
@@ -881,10 +969,10 @@ def _adjust_greenfrac_landusef(
 
 
 def _add_frc_lu_index_2_wrf(
-        info: Info,
-        FRC_THRESHOLD: float,
-        LCZ_NAT_MASK: bool,
-        ucp_table: pd.DataFrame,
+    info: Info,
+    FRC_THRESHOLD: float,
+    LCZ_NAT_MASK: bool,
+    ucp_table: pd.DataFrame,
 ) -> xr.Dataset:
 
     '''
@@ -909,17 +997,14 @@ def _add_frc_lu_index_2_wrf(
 
     # Make a FRC_URB field and store aggregated data.
     dst_data[ucp_key] = dst_data['LU_INDEX'].copy()
-    dst_data[ucp_key] = (
-                    ('Time', 'south_north', 'west_east'),
-                    frc_urb.data
-                )
+    dst_data[ucp_key] = (('Time', 'south_north', 'west_east'), frc_urb.data)
 
     # Add proper attributes to the FRC_URB2D field
     dst_data[ucp_key].attrs['FieldType'] = np.intc(104)
-    dst_data[ucp_key].attrs['MemoryOrder'] = "XY"
-    dst_data[ucp_key].attrs['units'] = "-"
-    dst_data[ucp_key].attrs['description'] = "ufrac"
-    dst_data[ucp_key].attrs['stagger'] = "M"
+    dst_data[ucp_key].attrs['MemoryOrder'] = 'XY'
+    dst_data[ucp_key].attrs['units'] = '-'
+    dst_data[ucp_key].attrs['description'] = 'ufrac'
+    dst_data[ucp_key].attrs['stagger'] = 'M'
     dst_data[ucp_key].attrs['sr_x'] = np.intc(1)
     dst_data[ucp_key].attrs['sr_y'] = np.intc(1)
 
@@ -931,7 +1016,7 @@ def _add_frc_lu_index_2_wrf(
     )
 
     # 2) as LU_INDEX = 30 to 41, as LCZ classes.
-    dst_data['LU_INDEX'].values[0,frc_mask] = lcz_resampled
+    dst_data['LU_INDEX'].values[0, frc_mask] = lcz_resampled
 
     # Also adjust GREENFRAC and LANDUSEF
     dst_data = _adjust_greenfrac_landusef(info, dst_data, frc_mask)
@@ -939,26 +1024,27 @@ def _add_frc_lu_index_2_wrf(
     return dst_data
 
 
-def _initialize_urb_param(dst_data: xr.Dataset) -> xr. Dataset:
+def _initialize_urb_param(dst_data: xr.Dataset) -> xr.Dataset:
 
-    ''' Helper function to initialize URB_PARAM in WRF geo_em file'''
+    '''Helper function to initialize URB_PARAM in WRF geo_em file'''
 
-    URB_PARAM = np.zeros([1, 132,
-                          len(dst_data.south_north),
-                          len(dst_data.west_east)])
+    URB_PARAM = np.zeros([1, 132, len(dst_data.south_north), len(dst_data.west_east)])
 
     # Add to destination WRF file, with attributes
-    dst_data['URB_PARAM'] = \
-        (('Time', 'num_urb_params', 'south_north', 'west_east'), URB_PARAM)
+    dst_data['URB_PARAM'] = (
+        ('Time', 'num_urb_params', 'south_north', 'west_east'),
+        URB_PARAM,
+    )
     dst_data['URB_PARAM'].attrs['FieldType'] = np.intc(104)
-    dst_data['URB_PARAM'].attrs['MemoryOrder'] = "XYZ"
-    dst_data['URB_PARAM'].attrs['units'] = "dimensionless"
-    dst_data['URB_PARAM'].attrs['description'] = "all urban parameters"
-    dst_data['URB_PARAM'].attrs['stagger'] = "M"
+    dst_data['URB_PARAM'].attrs['MemoryOrder'] = 'XYZ'
+    dst_data['URB_PARAM'].attrs['units'] = 'dimensionless'
+    dst_data['URB_PARAM'].attrs['description'] = 'all urban parameters'
+    dst_data['URB_PARAM'].attrs['stagger'] = 'M'
     dst_data['URB_PARAM'].attrs['sr_x'] = np.intc(1)
     dst_data['URB_PARAM'].attrs['sr_y'] = np.intc(1)
 
     return dst_data
+
 
 def create_lcz_params_file(
     info: Info,
@@ -984,28 +1070,27 @@ def create_lcz_params_file(
     dst_final = _initialize_urb_param(dst_data=dst_data)
 
     # get frc_mask, to only set values where FRC_URB2D > 0.
-    frc_mask = dst_final.FRC_URB2D.values[0,:,:] != 0
+    frc_mask = dst_final.FRC_URB2D.values[0, :, :] != 0
 
     # Define the UCPs that need to be integrated,
     # together with their positions (index starts at 1) in URB_PARAMS
     # HGT_URB2D and HI_URB2D follow a different approach, see further.
     ucp_dict = {
-        'LP_URB2D'  : 91,
-        'MH_URB2D'  : 92,
+        'LP_URB2D': 91,
+        'MH_URB2D': 92,
         'STDH_URB2D': 93,
-        'HGT_URB2D' : 94,
-        'LB_URB2D'  : 95,
-        'LF_URB2D'  : 96,   # 97, 98, 99, for all 4 directions
-        'HI_URB2D'  : 118,  # Goes on until index 132
+        'HGT_URB2D': 94,
+        'LB_URB2D': 95,
+        'LF_URB2D': 96,  # 97, 98, 99, for all 4 directions
+        'HI_URB2D': 118,  # Goes on until index 132
     }
 
     for ucp_key in ucp_dict.keys():
 
-        print(f"> Processing {ucp_key} ...")
+        print(f'> Processing {ucp_key} ...')
 
         # Obtain aggregated LCZ-based UCP values
-        if ucp_key in ['MH_URB2D', 'STDH_URB2D', 'LB_URB2D',
-                       'LF_URB2D', 'LP_URB2D']:
+        if ucp_key in ['MH_URB2D', 'STDH_URB2D', 'LB_URB2D', 'LF_URB2D', 'LP_URB2D']:
             ucp_res = _ucp_resampler(
                 info=info,
                 ucp_key=ucp_key,
@@ -1033,18 +1118,18 @@ def create_lcz_params_file(
                 ucp_res.values[:, frc_mask == 0] = 0
                 dst_final['URB_PARAM'][:, (ucp_dict[ucp_key] - 1 + i), :, :] = ucp_res
         if ucp_key == 'HI_URB2D':
-            ucp_res[:,frc_mask==0] = 0
-            dst_final['URB_PARAM'][0, (ucp_dict[ucp_key] - 1):, :, :] = ucp_res
+            ucp_res[:, frc_mask == 0] = 0
+            dst_final['URB_PARAM'][0, (ucp_dict[ucp_key] - 1) :, :, :] = ucp_res
         else:
             ucp_res.values[:, frc_mask == 0] = 0
-            dst_final['URB_PARAM'].values[0, (ucp_dict[ucp_key] - 1), :,:] = ucp_res
+            dst_final['URB_PARAM'].values[0, (ucp_dict[ucp_key] - 1), :, :] = ucp_res
 
     # Make sure URB_PARAM is float32
     dst_final['URB_PARAM'] = dst_final.URB_PARAM.astype('float32')
 
     # Expand attribute title
     att_title = dst_final.attrs['TITLE']
-    dst_final.attrs['TITLE'] = f"{att_title}, perturbed by W2W"
+    dst_final.attrs['TITLE'] = f'{att_title}, perturbed by W2W'
 
     # Add/Change some additional global attributes,
     # including NBUI_MAX = max. nr. of HI intervals over the grid
@@ -1056,13 +1141,16 @@ def create_lcz_params_file(
     for key in glob_attrs.keys():
         dst_final.attrs[key] = np.intc(glob_attrs[key])
 
-    #Add DESCRIPTION in attrs, referring to tool
-    gh_ref = "Demuzere, M., Argüeso, D., Zonato, A., & Kittner, J. (2021). \n" \
-             "W2W: A Python package that injects WUDAPT's Local Climate Zone \n" \
-             "information in WRF [Computer software]. \n" \
-             "https://github.com/matthiasdemuzere/w2w"
-    dst_final.attrs['DESCRIPTION'] = \
-        f"W2W.py tool used to create geo_em*.nc file:\n {gh_ref}"
+    # Add DESCRIPTION in attrs, referring to tool
+    gh_ref = (
+        'Demuzere, M., Argüeso, D., Zonato, A., & Kittner, J. (2021). \n'
+        "W2W: A Python package that injects WUDAPT's Local Climate Zone \n"
+        'information in WRF [Computer software]. \n'
+        'https://github.com/matthiasdemuzere/w2w'
+    )
+    dst_final.attrs[
+        'DESCRIPTION'
+    ] = f'W2W.py tool used to create geo_em*.nc file:\n {gh_ref}'
 
     # Save back to file
     if os.path.exists(info.dst_lcz_params_file):
@@ -1085,8 +1173,8 @@ def create_lcz_extent_file(info: Info) -> None:
     dst_extent = dst_params.copy()
 
     dst_data_orig = xr.open_dataset(info.dst_file)
-    orig_num_land_cat=dst_data_orig.NUM_LAND_CAT
-    orig_luf_description=dst_data_orig.LANDUSEF.description
+    orig_num_land_cat = dst_data_orig.NUM_LAND_CAT
+    orig_luf_description = dst_data_orig.LANDUSEF.description
 
     lu_index = dst_extent.LU_INDEX.values
     lu_index[lu_index >= 31] = 13
@@ -1094,7 +1182,7 @@ def create_lcz_extent_file(info: Info) -> None:
     dst_extent.LU_INDEX.values = lu_index
 
     # Remove some unnecesary variables to reduce file size
-    dst_extent = dst_extent.drop_vars(['FRC_URB2D','URB_PARAM'])
+    dst_extent = dst_extent.drop_vars(['FRC_URB2D', 'URB_PARAM'])
 
     # Reset LANDUSEF again to 21 classes.
     luf_attrs = dst_extent.LANDUSEF.attrs
@@ -1102,9 +1190,9 @@ def create_lcz_extent_file(info: Info) -> None:
     dst_extent = dst_extent.drop_vars('LANDUSEF')
 
     # Add back to data-array, including (altered) attributes
-    dst_extent['LANDUSEF'] =     (
+    dst_extent['LANDUSEF'] = (
         ('Time', 'land_cat', 'south_north', 'west_east'),
-        luf_values[:,:orig_num_land_cat,:,:]
+        luf_values[:, :orig_num_land_cat, :, :],
     )
     dst_extent['LANDUSEF'].values[0, 12, frc_mask] = 1
     dst_extent['LANDUSEF'] = dst_extent.LANDUSEF.astype('float32')
@@ -1121,18 +1209,17 @@ def create_lcz_extent_file(info: Info) -> None:
     dst_extent.to_netcdf(info.dst_lcz_extent_file)
 
 
-
 def expand_land_cat_parents(info: Info) -> None:
 
     # Get final domain number
     domain_nr = int(info.dst_file[-5:-3])
 
-    #list domain numbers to loop over
-    domain_lst = list(np.arange(1,domain_nr,1))
+    # list domain numbers to loop over
+    domain_lst = list(np.arange(1, domain_nr, 1))
 
     for i in domain_lst:
 
-        ifile = f"{info.dst_file[:-5]}{i:02d}.nc"
+        ifile = f'{info.dst_file[:-5]}{i:02d}.nc'
 
         if os.path.exists(ifile):
 
@@ -1158,12 +1245,13 @@ def expand_land_cat_parents(info: Info) -> None:
                     # Add back to data-array, including (altered) attributes
                     da['LANDUSEF'] = (
                         ('Time', 'land_cat', 'south_north', 'west_east'),
-                        landusef_new
+                        landusef_new,
                     )
                     da['LANDUSEF'] = da.LANDUSEF.astype('float32')
 
-                    luf_attrs['description'] = 'Noah-modified 41-category ' \
-                                               'IGBP-MODIS landuse'
+                    luf_attrs['description'] = (
+                        'Noah-modified 41-category ' 'IGBP-MODIS landuse'
+                    )
                     for key in luf_attrs.keys():
                         da['LANDUSEF'].attrs[key] = luf_attrs[key]
 
@@ -1171,121 +1259,135 @@ def expand_land_cat_parents(info: Info) -> None:
                     da.to_netcdf(ofile)
 
                 else:
-                    print(f"> Parent domain d{i:02d}.nc already contains 41 LC classes")
+                    print(f'> Parent domain d{i:02d}.nc already contains 41 LC classes')
             except Exception:
                 err = traceback.format_exc()
                 print(f'Cannot read NUM_LAND_CAT and LANDUSEF dimensions\n{err}')
 
         else:
-            print(f"WARNING: Parent domain {info.dst_file[:-5]}{i:02d}.nc"
-                  f" not found.\n"
-                  f"Please make sure the parent domain files are "
-                  f"in {info.io_dir}\n"
-                  f"Without this information, you will not be able to produce "
-                  f"the boundary conditions with real.exe.")
+            print(
+                f'WARNING: Parent domain {info.dst_file[:-5]}{i:02d}.nc'
+                f' not found.\n'
+                f'Please make sure the parent domain files are '
+                f'in {info.io_dir}\n'
+                f'Without this information, you will not be able to produce '
+                f'the boundary conditions with real.exe.'
+            )
 
 
 def checks_and_cleaning(info: Info, ucp_table: pd.DataFrame, nbui_max: float) -> None:
 
     'Sanity checks and cleaning'
 
-    OKGREEN = "\033[0;32m"
+    OKGREEN = '\033[0;32m'
     WARNING = '\033[0;35m'
     ENDC = '\033[0m'
 
-    base_text = f"> Check 1: Urban class removed from " \
-          f"{info.dst_nu_file.split('/')[-1]}?"
+    base_text = (
+        f'> Check 1: Urban class removed from ' f"{info.dst_nu_file.split('/')[-1]}?"
+    )
     ifile = info.dst_nu_file
     da = xr.open_dataset(ifile)
     if 13 in da.LU_INDEX.values:
-        print(f"{base_text}\n{WARNING} WARNING: Urban land use "
-              f"still present {ENDC}")
+        print(
+            f'{base_text}\n{WARNING} WARNING: Urban land use ' f'still present {ENDC}'
+        )
     else:
-        print(f"{base_text}{OKGREEN} OK {ENDC}")
+        print(f'{base_text}{OKGREEN} OK {ENDC}')
 
-    base_text = f"> Check 2: LCZ Urban extent present in " \
-          f"{info.dst_lcz_extent_file.split('/')[-1]}?"
+    base_text = (
+        f'> Check 2: LCZ Urban extent present in '
+        f"{info.dst_lcz_extent_file.split('/')[-1]}?"
+    )
     ifile = info.dst_lcz_extent_file
     da = xr.open_dataset(ifile)
     if not 13 in da.LU_INDEX.values:
-        print(f"{base_text}\n{WARNING} WARNING: LCZ-based urban "
-              f"extent missing {ENDC}")
+        print(
+            f'{base_text}\n{WARNING} WARNING: LCZ-based urban ' f'extent missing {ENDC}'
+        )
     else:
-        print(f"{base_text}{OKGREEN} OK {ENDC}")
+        print(f'{base_text}{OKGREEN} OK {ENDC}')
 
-
-    base_text = f"> Check 3: Urban LCZ classes exists in " \
-          f"{info.dst_lcz_params_file.split('/')[-1]}?"
+    base_text = (
+        f'> Check 3: Urban LCZ classes exists in '
+        f"{info.dst_lcz_params_file.split('/')[-1]}?"
+    )
     ifile = info.dst_lcz_params_file
     da = xr.open_dataset(ifile)
     if 13 in da.LU_INDEX.values:
-        print(f"{base_text}\n{WARNING} WARNING: Urban extent still "
-              f"defined via LU_INDEX = 13? {ENDC}")
+        print(
+            f'{base_text}\n{WARNING} WARNING: Urban extent still '
+            f'defined via LU_INDEX = 13? {ENDC}'
+        )
     else:
         LU_values = np.unique(da.LU_INDEX.values.flatten())
         LCZs = [int(i) for i in list(LU_values[LU_values >= 31] - 30)]
-        print(f"{base_text}{OKGREEN} OK: LCZ Classes ({LCZs}) "
-              f"present {ENDC}")
+        print(f'{base_text}{OKGREEN} OK: LCZ Classes ({LCZs}) ' f'present {ENDC}')
 
-    base_text = f"> Check 4: FRC_URB2D present in " \
-          f"{info.dst_lcz_params_file.split('/')[-1]}?"
+    base_text = (
+        f'> Check 4: FRC_URB2D present in '
+        f"{info.dst_lcz_params_file.split('/')[-1]}?"
+    )
     ifile = info.dst_lcz_params_file
     da = xr.open_dataset(ifile)
     if 'FRC_URB2D' not in list(da.keys()):
-        print(f"{base_text}\n{WARNING} WARNING: FRC_URB2D not "
-              f"present in {ifile} {ENDC}")
+        print(
+            f'{base_text}\n{WARNING} WARNING: FRC_URB2D not '
+            f'present in {ifile} {ENDC}'
+        )
         frc_urb2d_present = 'NO'
     else:
         FRC_URB2D = da.FRC_URB2D.values
-        print(f"{base_text}{OKGREEN} OK: FRC_URB2D values "
-              f"range between {'{:0.2f}'.format(FRC_URB2D.min())} and "
-              f"{'{:0.2f}'.format(FRC_URB2D.max())} {ENDC}")
+        print(
+            f'{base_text}{OKGREEN} OK: FRC_URB2D values '
+            f"range between {'{:0.2f}'.format(FRC_URB2D.min())} and "
+            f"{'{:0.2f}'.format(FRC_URB2D.max())} {ENDC}"
+        )
         frc_urb2d_present = 'YES'
 
-    base_text = f"> Check 5: URB_PARAMS matrix present in file " \
-          f"{info.dst_lcz_params_file.split('/')[-1]}?"
+    base_text = (
+        f'> Check 5: URB_PARAMS matrix present in file '
+        f"{info.dst_lcz_params_file.split('/')[-1]}?"
+    )
     ifile = info.dst_lcz_params_file
     da = xr.open_dataset(ifile)
     if 'URB_PARAM' not in list(da.keys()):
-        print(f"{base_text}\n{WARNING} WARNING: URB_PARAM matrix not "
-              f"present {ENDC}")
+        print(
+            f'{base_text}\n{WARNING} WARNING: URB_PARAM matrix not ' f'present {ENDC}'
+        )
         urb_param_present = 'NO'
     else:
-        print(f"{base_text}{OKGREEN} OK {ENDC}")
+        print(f'{base_text}{OKGREEN} OK {ENDC}')
         urb_param_present = 'YES'
 
     if urb_param_present == 'YES':
-        base_text = "> Check 6: Do URB_PARAM variable values follow expected " \
-              f"range in {info.dst_lcz_params_file.split('/')[-1]}?"
+        base_text = (
+            '> Check 6: Do URB_PARAM variable values follow expected '
+            f"range in {info.dst_lcz_params_file.split('/')[-1]}?"
+        )
         ifile = info.dst_lcz_params_file
         da = xr.open_dataset(ifile)
 
         # URB PAR Indices: https://ral.ucar.edu/sites/default/files/public/product-tool/NUDAPT_44_Documentation.pdf
         ucp_dict: Dict[str, Dict[str, Any]] = {
-            'LP_URB2D'  : {
-                'index': 91,
-                'range': [0,1]
-            },
-            'MH_URB2D'  : {
+            'LP_URB2D': {'index': 91, 'range': [0, 1]},
+            'MH_URB2D': {
                 'index': 92,
-                'range': [0, ucp_table['MH_URB2D'].max() + ucp_table['MH_URB2D'].std()]
+                'range': [0, ucp_table['MH_URB2D'].max() + ucp_table['MH_URB2D'].std()],
             },
             'STDH_URB2D': {
                 'index': 93,
-                'range': [0, ucp_table['MH_URB2D_MAX'].max() + ucp_table['MH_URB2D'].std()]
+                'range': [
+                    0,
+                    ucp_table['MH_URB2D_MAX'].max() + ucp_table['MH_URB2D'].std(),
+                ],
             },
-            'HGT_URB2D' : {
+            'HGT_URB2D': {
                 'index': 94,
-                'range': [0, ucp_table['MH_URB2D'].max() + ucp_table['MH_URB2D'].std()]
+                'range': [0, ucp_table['MH_URB2D'].max() + ucp_table['MH_URB2D'].std()],
             },
-            'LB_URB2D'  : {
-                'index': 95,
-                'range': [0, 5]
-            },
-            'LF_URB2D' : {
-                'index': 96,
-                'range': [0, 5]
-            },
+            'LB_URB2D': {'index': 95, 'range': [0, 5]},
+            'LF_URB2D': {'index': 96, 'range': [0, 5]},
         }
 
         def _check_range(darr: NDArray[np.float_], exp_range: List[int]) -> int:
@@ -1300,60 +1402,77 @@ def checks_and_cleaning(info: Info, ucp_table: pd.DataFrame, nbui_max: float) ->
         print(base_text)
         for ucp_key in ucp_dict.keys():
 
-            darr = da.URB_PARAM[0, ucp_dict[ucp_key]['index'] - 1, :, :].values.flatten()
+            darr = da.URB_PARAM[
+                0, ucp_dict[ucp_key]['index'] - 1, :, :
+            ].values.flatten()
             exp_range = ucp_dict[ucp_key]['range']
 
             result = _check_range(darr, exp_range)
 
             if result == -1:
-                print(f"{WARNING} WARNING: {ucp_key} exceeds "
-                      f"expected value range {ENDC}")
+                print(
+                    f'{WARNING} WARNING: {ucp_key} exceeds '
+                    f'expected value range {ENDC}'
+                )
             else:
-                print(f"{OKGREEN}   + OK for {ucp_key} {ENDC}")
+                print(f'{OKGREEN}   + OK for {ucp_key} {ENDC}')
 
-        base_text = "> Check 7: Does HI_URB2D sum to 100% for urban pixels " \
-              f"in {info.dst_lcz_params_file.split('/')[-1]}?"
+        base_text = (
+            '> Check 7: Does HI_URB2D sum to 100% for urban pixels '
+            f"in {info.dst_lcz_params_file.split('/')[-1]}?"
+        )
         da = xr.open_dataset(info.dst_lcz_params_file)
         hi_sum = da.URB_PARAM[0, 117:, :, :].sum(axis=0)
         hi_sum = hi_sum.where(hi_sum != 0, drop=True)
 
         if np.nanmax(np.abs((100 - hi_sum).values)) > 0.1:
-            print(f"{base_text}\n{WARNING} WARNING: Not all pixels "
-                  f"have sum HI_URB2D == 100% {ENDC}")
+            print(
+                f'{base_text}\n{WARNING} WARNING: Not all pixels '
+                f'have sum HI_URB2D == 100% {ENDC}'
+            )
         else:
-            print(f"{base_text}{OKGREEN} OK {ENDC}")
+            print(f'{base_text}{OKGREEN} OK {ENDC}')
 
     if frc_urb2d_present == 'YES':
-        base_text = "> Check 8: Do FRC_URB and LCZs (from LU_INDEX) cover same extent " \
-              f"in {info.dst_lcz_params_file.split('/')[-1]}?"
+        base_text = (
+            '> Check 8: Do FRC_URB and LCZs (from LU_INDEX) cover same extent '
+            f"in {info.dst_lcz_params_file.split('/')[-1]}?"
+        )
         frc_urb2d = xr.open_dataset(info.dst_lcz_params_file).FRC_URB2D
         lu_index = xr.open_dataset(info.dst_lcz_params_file).LU_INDEX
         frc_urb_res = xr.where(frc_urb2d != 0, 1, 0)
         lu_index_res = xr.where(lu_index >= 31, 1, 0)
 
         if int((frc_urb_res - lu_index_res).sum()) != 0:
-            print(f"{base_text}\n{WARNING} WARNING: FRC_URB and LCZs in "
-                  f"LU_INDEX do not cover same extent {ENDC}")
+            print(
+                f'{base_text}\n{WARNING} WARNING: FRC_URB and LCZs in '
+                f'LU_INDEX do not cover same extent {ENDC}'
+            )
         else:
-            print(f"{base_text}{OKGREEN} OK {ENDC}")
+            print(f'{base_text}{OKGREEN} OK {ENDC}')
 
-    base_text = "> Check 9: Extent and # urban pixels same for " \
-          "*_extent.nc and *_params.nc output file?"
+    base_text = (
+        '> Check 9: Extent and # urban pixels same for '
+        '*_extent.nc and *_params.nc output file?'
+    )
     da_e = xr.open_dataset(info.dst_lcz_extent_file)
     da_p = xr.open_dataset(info.dst_lcz_params_file)
-    da_e_res = xr.where(da_e.LU_INDEX == 13, 1,0)
-    da_p_res = xr.where(da_p.LU_INDEX >=31, 1,0)
+    da_e_res = xr.where(da_e.LU_INDEX == 13, 1, 0)
+    da_p_res = xr.where(da_p.LU_INDEX >= 31, 1, 0)
 
     if int((da_p_res - da_e_res).sum()) != 0:
-        print(f"{base_text}\n {WARNING} WARNING: Different "
-              f"# urban pixels (or extent) "
-              f"according to LU_INDEX: "
-              f" - extent: {int(da_e_res.sum().values)}"
-              f" - params: {int(da_p_res.sum().values)} {ENDC}"
-              )
+        print(
+            f'{base_text}\n {WARNING} WARNING: Different '
+            f'# urban pixels (or extent) '
+            f'according to LU_INDEX: '
+            f' - extent: {int(da_e_res.sum().values)}'
+            f' - params: {int(da_p_res.sum().values)} {ENDC}'
+        )
     else:
-        print(f"{base_text}{OKGREEN} OK, urban extent the same "
-              f"({int(da_p_res.sum().values)}) {ENDC}")
+        print(
+            f'{base_text}{OKGREEN} OK, urban extent the same '
+            f'({int(da_p_res.sum().values)}) {ENDC}'
+        )
 
     print('> Cleaning up ... all done!')
     if os.path.exists(info.dst_gridinfo):
@@ -1361,15 +1480,18 @@ def checks_and_cleaning(info: Info, ucp_table: pd.DataFrame, nbui_max: float) ->
     if os.path.exists(info.src_file_clean):
         os.remove(info.src_file_clean)
 
-    print(f"\n\n ----------- !! NOTE !! --------- \n"
-          f" Set nbui_max to {nbui_max} during compilation, "
-          f"in order to optimize memory storage.\n\n")
+    print(
+        f'\n\n ----------- !! NOTE !! --------- \n'
+        f' Set nbui_max to {nbui_max} during compilation, '
+        f'in order to optimize memory storage.\n\n'
+    )
+
 
 ###############################################################################
 ##### __main__  scope
 ###############################################################################
 
-if __name__ == "__main__":
+if __name__ == '__main__':
 
     raise SystemExit(main())
 


### PR DESCRIPTION
Just a suggestion. Happy to discuss this further. To not having to worry about code style anymore, adding a code formatter, in this case `black` would make things a lot easier. Adding `flake8` to catch some bugs would also make sense. So far it catched things like this:
```
w2w/w2w.py:1304:9: F601 dictionary key 'LF_URB2D' repeated with different values
w2w/w2w.py:1305:9: F601 dictionary key 'LF_URB2D' repeated with different values
w2w/w2w.py:1306:9: F601 dictionary key 'LF_URB2D' repeated with different values
w2w/w2w.py:1307:9: F601 dictionary key 'LF_URB2D' repeated with different values
```
Finally -- I am not sure about it -- would be adding `mypy` as a type checker and type annotating the code. Unfortunatelly most of the sciency packages don't have type annotations yet. I'd have to have a closer look on how to realize this and if there we can even get a benefit out of this.