### PR TITLE
add complete type annotations

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,3 +15,8 @@ repos:
     rev: v1.17.0
     hooks:
     -   id: setup-cfg-fmt
+-   repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v0.931
+    hooks:
+    -   id: mypy
+        additional_dependencies: [numpy==1.22.2]

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,7 @@ classifiers =
 packages = find:
 install_requires =
     ecmwflibs
-    numpy
+    numpy>=1.21
     pandas
     rasterio
     rioxarray
@@ -50,4 +50,18 @@ universal = True
 plugins = covdefaults
 
 [coverage:report]
-fail_under = 1
+fail_under = 98
+
+[mypy]
+plugins = numpy.typing.mypy_plugin
+check_untyped_defs = true
+disallow_any_generics = true
+disallow_incomplete_defs = true
+disallow_untyped_defs = true
+no_implicit_optional = true
+
+[mypy-testing.*]
+disallow_untyped_defs = false
+
+[mypy-tests.*]
+disallow_untyped_defs = false


### PR DESCRIPTION
This adds type annotations to all function and checks them using `mypy`

- one refactoring was needed, to be able to infer the correct types. Instead of using a dict for the `info` configuration, it is now using a `NamedTuple`. This enables us to type each argument an it being immutable. [`TypedDict`](https://docs.python.org/3/library/typing.html#typing.TypedDict) was only added recently in `3.7`.
- so it basically just replaces all `key` lookups with attribute lookups
- Numpy is slowly adding typing support, so the `NDArray` is only available starting with `1.21`, so we need to soft pin this version.

One other thing to mention is the `info_mock` fixture. It allows to always have a properly constructed `Info` class, but allow construction with different attributes, to be able to test behaviors.