### PR TITLE
make w2w work on py310

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9, "3.10"]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,9 @@ jobs:
       matrix:
         python-version: [3.7, 3.8, 3.9, "3.10"]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: install tox

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,13 +23,15 @@ classifiers =
 packages = find:
 install_requires =
     ecmwflibs
+    h5netcdf
+    netCDF4
     numpy>=1.21
     pandas
     rasterio>=1.1.6
     rioxarray
     scipy
     tqdm
-    xarray[io]
+    xarray
     importlib-metadata;python_version<"3.9"
     importlib-resources;python_version<"3.9"
 python_requires = >=3.7

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37, py38, py39, pre-commit
+envlist = py37, py38, py39, py310, pre-commit
 skip_missing_interpreters = true
 
 [testenv]


### PR DESCRIPTION
To be able to use w2w on python3.10, we need to drop the `io` extras in xarray, because it also depends on `pydap` which hasn't released a version to PyPi since 2017.
However we only seem to need `netCDF4` and `h5netcdf` which we can pick up as a direct dependency. This also makes the environment 45 MB smaller, which is a nice side effect.