### PR TITLE
fix import sorting by moving np.seterr down

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
     -   id: double-quote-string-fixer
     -   id: check-merge-conflict
 -   repo: https://github.com/asottile/reorder_python_imports
-    rev: v3.3.0
+    rev: v3.8.1
     hooks:
     -   id: reorder-python-imports
         args: [--py3-plus]

--- a/w2w/w2w.py
+++ b/w2w/w2w.py
@@ -1,19 +1,10 @@
-import numpy as np
-
-np.seterr(divide='ignore', invalid='ignore')
-import pandas as pd
-import rioxarray as rxr
-import rasterio
-import xarray as xr
-from rasterio.warp import reproject, Resampling
-from rasterio.transform import Affine
-from scipy.stats import mode, truncnorm
-import scipy.spatial as spatial
-import os, sys
 import argparse
-from argparse import RawTextHelpFormatter
+import os
+import sys
 import traceback
-from typing import Dict, Any
+from argparse import RawTextHelpFormatter
+from typing import Any
+from typing import Dict
 from typing import List
 from typing import NamedTuple
 from typing import Optional
@@ -21,11 +12,24 @@ from typing import Sequence
 from typing import SupportsInt
 from typing import Tuple
 from typing import Union
-from numpy.typing import NDArray
-from scipy import stats
+
+import numpy as np
+import pandas as pd
 import pyproj
-from pyproj import CRS, Transformer
+import rioxarray as rxr
+import scipy.spatial as spatial
+import xarray as xr
+from numpy.typing import NDArray
+from pyproj import CRS
+from pyproj import Transformer
+from rasterio.transform import Affine
+from rasterio.warp import reproject
+from rasterio.warp import Resampling
+from scipy.stats import truncnorm
 from tqdm.auto import tqdm
+
+np.seterr(divide='ignore', invalid='ignore')
+
 
 if sys.version_info >= (3, 9):  # pragma: >=3.9 cover
     import importlib.metadata as importlib_metadata


### PR DESCRIPTION
`np.seterr(divide='ignore', invalid='ignore')` being second, previously blocked the import sort to do its job. This is now fixed.