### PR TITLE
display custom error message when input is not found

### DIFF
--- a/tests/w2w_test.py
+++ b/tests/w2w_test.py
@@ -106,10 +106,10 @@ def test_get_lcz_band_not_found(info_mock, capsys):
         _get_lcz_band(info=info, args=args)
 
     out, _ = capsys.readouterr()
-    assert out == (
+    assert (
         f'ERROR: cannot find LCZ map file: '
-        f'{os.path.join(os.getcwd(), "testing/not_existing.tif")}\n'
-    )
+        f'{os.path.join(os.getcwd(), "testing/not_existing.tif")}'
+    ) in out
     assert exc_info.value.args[0].args[0] == (
         'testing/not_existing.tif: No such file or directory'
     )

--- a/tests/w2w_test.py
+++ b/tests/w2w_test.py
@@ -10,8 +10,6 @@ import rioxarray as rxr
 import xarray as xr
 from affine import Affine
 from pytest import approx
-from rasterio.warp import reproject
-from rasterio.warp import Resampling
 
 import w2w.w2w
 from w2w.w2w import _add_frc_lu_index_2_wrf
@@ -101,6 +99,22 @@ def test_get_lcz_band_lcz_generator(info_mock, capsys):
     assert LCZ_BAND == 1
 
 
+def test_get_lcz_band_not_found(info_mock, capsys):
+    info = info_mock({'src_file': 'testing/not_existing.tif'})
+    args = argparse.Namespace(LCZ_BAND=0)
+    with pytest.raises(SystemExit) as exc_info:
+        _get_lcz_band(info=info, args=args)
+
+    out, _ = capsys.readouterr()
+    assert out == (
+        f'ERROR: cannot find LCZ map file: '
+        f'{os.path.join(os.getcwd(), "testing/not_existing.tif")}\n'
+    )
+    assert exc_info.value.args[0].args[0] == (
+        'testing/not_existing.tif: No such file or directory'
+    )
+
+
 @pytest.mark.parametrize(
     ('arg', 'exp'),
     (
@@ -184,6 +198,24 @@ def test_check_lcz_integrity_exit_lcz_band(capsys, info_mock, tmpdir):
 
     out, _ = capsys.readouterr()
     assert 'ERROR: Can not read the requested LCZ_BAND' in out
+
+
+def test_check_lcz_integrity_dst_not_found(capsys, info_mock, tmpdir):
+    info = info_mock(
+        {
+            'src_file': 'sample_data/lcz_zaragoza.tif',
+            'dst_file': 'sample_data/not_existing_geo_em.d04.nc',
+        }
+    )
+    with pytest.raises(SystemExit) as exc_info:
+        check_lcz_integrity(info=info, LCZ_BAND=0)
+
+    out, _ = capsys.readouterr()
+    assert (
+        f'ERROR: cannot find geo_em* file: '
+        f'{os.path.join(os.getcwd(), "sample_data/not_existing_geo_em.d04.nc")}'
+    ) in out
+    assert 'No such file or directory' in exc_info.value.args[0].args
 
 
 def test_check_lcz_integrity_lcz_numbers_as_expected(capsys, tmpdir, info_mock):

--- a/w2w/w2w.py
+++ b/w2w/w2w.py
@@ -244,11 +244,15 @@ class Info(NamedTuple):
 
 def _get_lcz_band(info: Info, args: argparse.Namespace) -> int:
 
+    ERROR = '\033[0;31m'
+    ENDC = '\033[0m'
     # Read the file
     try:
         lcz = rxr.open_rasterio(info.src_file)
     except RasterioIOError as exc:
-        print(f'ERROR: cannot find LCZ map file: {os.path.abspath(info.src_file)}')
+        print(
+            f'{ERROR}ERROR: cannot find LCZ map file: {os.path.abspath(info.src_file)}{ENDC}'
+        )
         raise SystemExit(exc)
 
     # Check if 'lczFilter' is part of attributes. If so, band = 1

--- a/w2w/w2w.py
+++ b/w2w/w2w.py
@@ -22,6 +22,7 @@ import xarray as xr
 from numpy.typing import NDArray
 from pyproj import CRS
 from pyproj import Transformer
+from rasterio.errors import RasterioIOError
 from rasterio.transform import Affine
 from rasterio.warp import reproject
 from rasterio.warp import Resampling
@@ -244,7 +245,11 @@ class Info(NamedTuple):
 def _get_lcz_band(info: Info, args: argparse.Namespace) -> int:
 
     # Read the file
-    lcz = rxr.open_rasterio(info.src_file)
+    try:
+        lcz = rxr.open_rasterio(info.src_file)
+    except RasterioIOError as exc:
+        print(f'ERROR: cannot find LCZ map file: {os.path.abspath(info.src_file)}')
+        raise SystemExit(exc)
 
     # Check if 'lczFilter' is part of attributes. If so, band = 1
     if 'long_name' in lcz.attrs and 'lczFilter' in lcz.attrs['long_name']:
@@ -350,7 +355,13 @@ def check_lcz_integrity(info: Info, LCZ_BAND: int) -> None:
         )
         sys.exit(1)
 
-    wrf = xr.open_dataset(info.dst_file)
+    try:
+        wrf = xr.open_dataset(info.dst_file)
+    except FileNotFoundError as exc:
+        print(
+            f'{ERROR}ERROR: cannot find geo_em* file: {os.path.abspath(info.dst_file)}{ENDC}'
+        )
+        raise SystemExit(exc)
 
     # If any of [101, 102, 103, 104, 105, 106, 107] is in the lcz tif file.
     lcz_100 = np.array(


### PR DESCRIPTION
part of addressing the reviewer's feedback in #74

This will display a custom error message when one of the input files is not found, specifying the path it was looking at. This might be helpful for users fixing a relative path issue.