### PR TITLE
temporarily pin importlib to <5.0.0 since it breaks xarray in 3.7

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -28,6 +28,7 @@ install_requires =
     scipy
     tqdm
     xarray
+    importlib-metadata<5.0.0;python_version=="3.7"
     importlib-metadata;python_version<"3.9"
     importlib-resources;python_version<"3.9"
 python_requires = >=3.7


### PR DESCRIPTION
This fixes CI on python 3.7 where `importlib>=5.0.0` is incompatible with xarray after they dropped python 3.7 support (https://github.com/pydata/xarray/pull/5892) and causes Attribute errors. Once we also drop python 3.7, we can unpin this.