### PR TITLE
disable skipping the issue template, add note for uploading geo_em files

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+- wrf: WRF issue tracker
+  url: https://github.com/wrf-model/WRF
+  about: For issues with WRF, please use their [issue tracker](https://github.com/wrf-model/WRF)

--- a/.github/ISSUE_TEMPLATE/issue_template.yml
+++ b/.github/ISSUE_TEMPLATE/issue_template.yml
@@ -40,7 +40,11 @@ body:
     id: traceback
     attributes:
       label: 'Traceback'
+      description: Provide the full traceback from start to end and please indicate if you have changed anything (e.g. for privacy reasons)
       placeholder: "Traceback (most recent call last):\n..."
       render: console
     validations:
       required: false
+  - type: markdown
+    attributes:
+      value: If files are needed to reproduce the error (e.g. `geo_em.*.nc` files), please upload them.


### PR DESCRIPTION
this removes the "Don’t see your issue here? Open a blank issue." at the bottom of the issue page, forcing people to use the template. I hope this will increase the overall issue quality.

I also added a note about uploading files as well as linking to the WRF issue tracker directly when creating an issue (as a button).