### PR TITLE
fix CI by dropping python 3.7 which is EOL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10"]
+        python-version: [3.8, 3.9, "3.10", "3.11"]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ ci:
 
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v4.5.0
     hooks:
     -   id: trailing-whitespace
     -   id: end-of-file-fixer
@@ -14,27 +14,27 @@ repos:
     -   id: double-quote-string-fixer
     -   id: check-merge-conflict
 -   repo: https://github.com/asottile/reorder-python-imports
-    rev: v3.9.0
+    rev: v3.12.0
     hooks:
     -   id: reorder-python-imports
         args: [--py3-plus]
 -   repo: https://github.com/asottile/setup-cfg-fmt
-    rev: v2.3.0
+    rev: v2.5.0
     hooks:
     -   id: setup-cfg-fmt
 -   repo: https://github.com/psf/black
-    rev: 23.3.0
+    rev: 23.11.0
     hooks:
       - id: black-jupyter
         args: [--skip-string-normalization]
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.3.0
+    rev: v1.7.1
     hooks:
     -   id: mypy
         additional_dependencies: [numpy>=1.22.2]
 # jupyter hooks
 -   repo: https://github.com/nbQA-dev/nbQA
-    rev: 1.7.0
+    rev: 1.7.1
     hooks:
     -   id: nbqa
         name: mypy-juypter

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,10 +28,9 @@ install_requires =
     scipy
     tqdm
     xarray>=0.17.0
-    importlib-metadata<5.0.0;python_version=="3.7"
     importlib-metadata;python_version<"3.9"
     importlib-resources;python_version<"3.9"
-python_requires = >=3.7
+python_requires = >=3.8
 
 [options.packages.find]
 exclude =

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37, py38, py39, py310, pre-commit
+envlist = py38, py39, py310, py311, pre-commit
 skip_missing_interpreters = true
 
 [testenv]


### PR DESCRIPTION
3.7 is end of life and the CI fails because of it and is always red. Drop the support and test against the newer 3.11.

We cannot test against 3.12 since `ecmwflibs` has no wheel for 3.12 yet since it's only out a few months...