### PR TITLE
pin rasterio to < 1.4

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,7 @@ install_requires =
     netCDF4
     numpy>=1.21
     pandas
-    rasterio>=1.1.6
+    rasterio>=1.1.6,<1.4.0
     rioxarray
     scipy
     tqdm


### PR DESCRIPTION
resolves #134 

I am not sure what changed in `rasterio 1.4.0` - this is just to make it installable again, we need to investigate further at some point.